### PR TITLE
RST-1926-queried-hours

### DIFF
--- a/app/commands/build_response_command.rb
+++ b/app/commands/build_response_command.rb
@@ -32,6 +32,7 @@ class BuildResponseCommand < BaseCommand
   validate :validate_office_code_in_case_number
   validates :pdf_template_reference, inclusion: { in: ['et3-v1-en', 'et3-v1-cy'] }
   validates :email_template_reference, inclusion: { in: ['et3-v1-en', 'et3-v1-cy'] }
+  validates :queried_hours, numericality: { less_than_or_equal_to: 168.0, greater_than: 0.0 }, allow_nil: true
 
   def initialize(*)
     super

--- a/db/migrate/20190524080441_change_precision_of_queried_hours_in_responses.rb
+++ b/db/migrate/20190524080441_change_precision_of_queried_hours_in_responses.rb
@@ -1,0 +1,9 @@
+class ChangePrecisionOfQueriedHoursInResponses < ActiveRecord::Migration[5.2]
+  def up
+    change_column :responses, :queried_hours, :decimal, scale: 2, precision: 5
+  end
+
+  def down
+    change_column :responses, :queried_hours, :decimal, scale: 2, precision: 4
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1064,7 +1064,7 @@ CREATE TABLE public.responses (
     agree_with_claimants_description_of_job_or_title boolean,
     disagree_claimants_job_or_title character varying,
     agree_with_claimants_hours boolean,
-    queried_hours numeric(4,2),
+    queried_hours numeric(5,2),
     agree_with_earnings_details boolean,
     queried_pay_before_tax numeric(8,2),
     queried_pay_before_tax_period character varying,
@@ -2178,6 +2178,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190225190207'),
 ('20190312113307'),
 ('20190401204615'),
-('20190401204745');
+('20190401204745'),
+('20190524080441');
 
 

--- a/spec/commands/build_response_command_spec.rb
+++ b/spec/commands/build_response_command_spec.rb
@@ -88,11 +88,7 @@ RSpec.describe BuildResponseCommand do
     let(:office_code) { "%02d" % office.code }
 
     context 'with invalid case number' do
-      let(:data) do
-        {
-          case_number: '0034567/2016'
-        }
-      end
+      let(:data) { attributes_for(:json_response_data, :full, case_number: '0034567/2016') }
 
       it 'is false' do
         # Act
@@ -112,11 +108,7 @@ RSpec.describe BuildResponseCommand do
     end
 
     context 'with valid case number' do
-      let(:data) do
-        {
-          case_number: "#{office_code}34567/2016"
-        }
-      end
+      let(:data) { attributes_for(:json_response_data, :full, case_number: "#{office_code}34567/2016") }
 
       it 'is true' do
         # Act
@@ -128,11 +120,7 @@ RSpec.describe BuildResponseCommand do
     end
 
     context 'with invalid pdf_template_reference' do
-      let(:data) do
-        {
-          pdf_template_reference: '../../../etc/password'
-        }
-      end
+      let(:data) { attributes_for(:json_response_data, :full, pdf_template_reference: '../../../etc/password') }
 
       it 'contains the correct error key in the pdf_template_reference attributes' do
         # Act
@@ -145,11 +133,7 @@ RSpec.describe BuildResponseCommand do
     end
 
     context 'with invalid email_template_reference' do
-      let(:data) do
-        {
-          email_template_reference: '../../../etc/password'
-        }
-      end
+      let(:data) { attributes_for(:json_response_data, :full, email_template_reference: '../../../etc/password') }
 
       it 'contains the correct error key in the email_template_reference attributes' do
         # Act
@@ -162,7 +146,7 @@ RSpec.describe BuildResponseCommand do
     end
 
     context 'with queried_hours at maximum' do
-      let(:data) { { queried_hours: 168 } }
+      let(:data) { attributes_for(:json_response_data, :full, queried_hours: 168) }
 
       it 'is true' do
         # Act
@@ -174,7 +158,7 @@ RSpec.describe BuildResponseCommand do
     end
 
     context 'with queried hours over maximum' do
-      let(:data) { { queried_hours: 168.01 } }
+      let(:data) { attributes_for(:json_response_data, :full, queried_hours: 168.01) }
 
       it 'is false' do
         # Act
@@ -194,7 +178,7 @@ RSpec.describe BuildResponseCommand do
     end
 
     context 'with queried hours over the database limit' do
-      let(:data) { { queried_hours: 1000.00 } }
+      let(:data) { attributes_for(:json_response_data, :full, queried_hours: 1000.0) }
 
       it 'is false' do
         # Act

--- a/spec/commands/build_response_command_spec.rb
+++ b/spec/commands/build_response_command_spec.rb
@@ -160,5 +160,57 @@ RSpec.describe BuildResponseCommand do
       end
 
     end
+
+    context 'with queried_hours at maximum' do
+      let(:data) { { queried_hours: 168 } }
+
+      it 'is true' do
+        # Act
+        result = command.valid?
+
+        # Assert
+        expect(result).to be true
+      end
+    end
+
+    context 'with queried hours over maximum' do
+      let(:data) { { queried_hours: 168.01 } }
+
+      it 'is false' do
+        # Act
+        result = command.valid?
+
+        # Assert
+        expect(result).to be false
+      end
+
+      it 'contains the correct error key in the queried_hours attributes' do
+        # Act
+        command.valid?
+
+        # Assert
+        expect(command.errors.details[:queried_hours]).to include(hash_including(error: :less_than_or_equal_to, value: be_within(0.001).of(data[:queried_hours]), count: 168.0))
+      end
+    end
+
+    context 'with queried hours over the database limit' do
+      let(:data) { { queried_hours: 1000.00 } }
+
+      it 'is false' do
+        # Act
+        result = command.valid?
+
+        # Assert
+        expect(result).to be false
+      end
+
+      it 'contains the correct error key in the queried_hours attributes' do
+        # Act
+        command.valid?
+
+        # Assert
+        expect(command.errors.details[:queried_hours]).to include(hash_including(error: :less_than_or_equal_to, value: be_within(0.001).of(data[:queried_hours]), count: 168))
+      end
+    end
   end
 end

--- a/spec/factories/json/json_response_factory.rb
+++ b/spec/factories/json/json_response_factory.rb
@@ -96,7 +96,7 @@ FactoryBot.define do
       agree_with_claimants_description_of_job_or_title { false }
       disagree_claimants_job_or_title { "lorem ipsum job title" }
       agree_with_claimants_hours { false }
-      queried_hours { 32.0 }
+      queried_hours { 101.01 }
       agree_with_earnings_details { false }
       queried_pay_before_tax { 1000.0 }
       queried_pay_before_tax_period { "Monthly" }

--- a/spec/factories/json/json_response_factory.rb
+++ b/spec/factories/json/json_response_factory.rb
@@ -119,6 +119,10 @@ FactoryBot.define do
       case_number { '6554321/2017' }
     end
 
+    trait :invalid_queried_hours do
+      queried_hours { 168.01 }
+    end
+
     trait :for_default_office do
       full
       case_number { '9954321/2017' }


### PR DESCRIPTION
This PR fixes the API side of RST-1926 - i.e. the API protects itself from error.

It increases the column side for queried_hours which was precision 4, scale 2 - i.e. xx.yy - now increased
to precision 5, scale 2 - i.e. xxx.yy - as the maximum hours per week is 164

Added validation to the build response command to prevent values greater than 164 or less than or equal to zero