### PR TITLE
Rst 1930 ccd export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,4 +86,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'et_acas_api', path: 'vendor/gems/et_acas_api'
 
-
+gem 'et_exporter', git: 'https://github.com/hmcts/et_exporter_gem.git', tag: 'v0.1.1'

--- a/Gemfile
+++ b/Gemfile
@@ -86,4 +86,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'et_acas_api', path: 'vendor/gems/et_acas_api'
 
-gem 'et_exporter', git: 'https://github.com/hmcts/et_exporter_gem.git', tag: 'v0.1.1'
+gem 'et_exporter', git: 'https://github.com/hmcts/et_exporter_gem.git', tag: 'v0.2.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,15 @@
 GIT
+  remote: https://github.com/hmcts/et_exporter_gem.git
+  revision: a7e696528d4619fc48567c181bf8aa25e187ed0e
+  tag: v0.1.1
+  specs:
+    et_exporter (0.1.1)
+      jbuilder (~> 2.9, >= 2.9.1)
+      pg
+      rails (~> 5.2.3)
+      sidekiq (~> 5.2, >= 5.2.7)
+
+GIT
   remote: https://github.com/ministryofjustice/azure_env_secrets.git
   revision: b72195789c350839d8a7f492eb2938c5101d5400
   tag: v0.1.3
@@ -377,6 +388,7 @@ DEPENDENCIES
   et_acas_api!
   et_atos_export!
   et_atos_file_transfer!
+  et_exporter!
   et_fake_acas_server!
   factory_bot (~> 5.0)
   faker (~> 1.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/hmcts/et_exporter_gem.git
-  revision: a7e696528d4619fc48567c181bf8aa25e187ed0e
-  tag: v0.1.1
+  revision: 3b6da47e1224d8cb3a64b21052f7c62731d2966c
+  tag: v0.2.1
   specs:
-    et_exporter (0.1.1)
+    et_exporter (0.2.1)
       jbuilder (~> 2.9, >= 2.9.1)
       pg
       rails (~> 5.2.3)

--- a/app/controllers/concerns/cache_command_results.rb
+++ b/app/controllers/concerns/cache_command_results.rb
@@ -20,8 +20,11 @@ module CacheCommandResults
   end
 
   def cache_command_results_save(body)
+    request.body.rewind
+    request_body = request.body.read
+    request.body.rewind
     Command.create! id: params[:uuid],
-                    request_body: request.body,
+                    request_body: request_body,
                     request_headers: cache_command_results_request_headers,
                     response_body: body,
                     response_headers: response.headers.as_json,

--- a/app/event_handlers/claim_export_handler.rb
+++ b/app/event_handlers/claim_export_handler.rb
@@ -1,8 +1,8 @@
 class ClaimExportHandler
   def handle(claim)
     ExternalSystem.containing_office_code(claim.office_code).each do |system|
-      Export.claims.create resource: claim, external_system_id: system.id
+      export = Export.claims.create resource: claim, external_system_id: system.id
+      Rails.application.event_service.publish('ClaimQueuedForExport', export) if system.enabled? && system.export?
     end
-    Rails.application.event_service.publish('ClaimQueuedForExport', claim)
   end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -4,6 +4,7 @@
 # An internal join model not to be used directly
 class Export < ApplicationRecord
   belongs_to :resource, polymorphic: true
+  belongs_to :external_system
 
   scope :claims, -> { where(resource_type: 'Claim') }
   scope :responses, -> { where(resource_type: 'Response') }

--- a/db/migrate/20190618145253_add_export_queue_to_external_systems.rb
+++ b/db/migrate/20190618145253_add_export_queue_to_external_systems.rb
@@ -1,0 +1,6 @@
+class AddExportQueueToExternalSystems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :external_systems, :export_queue, :string
+    add_column :external_systems, :export, :boolean, default: false
+  end
+end

--- a/db/migrate/20190618145253_add_export_queue_to_external_systems.rb
+++ b/db/migrate/20190618145253_add_export_queue_to_external_systems.rb
@@ -2,5 +2,6 @@ class AddExportQueueToExternalSystems < ActiveRecord::Migration[5.2]
   def change
     add_column :external_systems, :export_queue, :string
     add_column :external_systems, :export, :boolean, default: false
+    ActiveRecord::Base.clear_cache!
   end
 end

--- a/db/migrate/20190618153701_add_ccd_manchester_external_system.rb
+++ b/db/migrate/20190618153701_add_ccd_manchester_external_system.rb
@@ -1,0 +1,29 @@
+class AddCcdManchesterExternalSystem < ActiveRecord::Migration[5.2]
+  class ExternalSystem < ActiveRecord::Base
+    self.table_name=:external_systems
+  end
+  
+  class ExternalSystemConfiguration < ActiveRecord::Base
+    self.table_name=:external_system_configurations
+  end
+
+  def up
+    ccd = ExternalSystem.create name: 'CCD Manchester',
+                                 reference: 'ccd_manchester',
+                                 enabled: true,
+                                 export: true,
+                                 export_queue: 'external_system_ccd',
+                                 office_codes: Office.pluck(:code).to_a
+
+    ExternalSystemConfiguration.create external_system_id: ccd.id,
+                                       key: 'user_id', value: '22'
+    ExternalSystemConfiguration.create external_system_id: ccd.id,
+                                       key: 'user_role', value: 'caseworker,caseworker-test,caseworker-employment-tribunal-manchester,caseworker-employment,caseworker-employment-tribunal-manchester-caseofficer,caseworker-publiclaw-localAuthority'
+    ExternalSystemConfiguration.create external_system_id: ccd.id,
+                                       key: 'case_type_id', value: 'EmpTrib_MVP_1.0_Manc'
+  end
+
+  def down
+    # Purposely do nothing - no point in going back on this
+  end
+end

--- a/db/migrate/20190618153701_add_ccd_manchester_external_system.rb
+++ b/db/migrate/20190618153701_add_ccd_manchester_external_system.rb
@@ -8,10 +8,11 @@ class AddCcdManchesterExternalSystem < ActiveRecord::Migration[5.2]
   end
 
   def up
+    return if ExternalSystem.find_by(reference: 'ccd_manchester').present?
     ccd = ExternalSystem.create name: 'CCD Manchester',
                                  reference: 'ccd_manchester',
                                  enabled: true,
-                                 export: true,
+                                 export: false,
                                  export_queue: 'external_system_ccd',
                                  office_codes: Office.pluck(:code).to_a
 

--- a/db/migrate/20190705075853_add_country_to_addresses.rb
+++ b/db/migrate/20190705075853_add_country_to_addresses.rb
@@ -1,0 +1,5 @@
+class AddCountryToAddresses < ActiveRecord::Migration[5.2]
+  def change
+    add_column :addresses, :country, :string
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,11 +27,19 @@ end
 atos = ExternalSystem.create name: 'ATOS Primary',
   reference: 'atos',
   enabled: true,
+  export: false,
   office_codes: Office.pluck(:code).to_a - [99]
 atos2 = ExternalSystem.create name: 'ATOS Secondary',
   reference: 'atos_secondary',
   enabled: true,
+  export: false,
   office_codes: [99]
+ccd = ExternalSystem.create name: 'CCD Manchester',
+  reference: 'ccd_manchester',
+  enabled: true,
+  export: true,
+  export_queue: 'external_system_ccd',
+  office_codes: Office.pluck(:code).to_a - [99]
 
 ExternalSystemConfiguration.create external_system_id: atos.id,
   key: 'username', value: ENV.fetch('ATOS_API_USERNAME', 'atos')
@@ -41,3 +49,11 @@ ExternalSystemConfiguration.create external_system_id: atos2.id,
   key: 'username', value: 'atos2'
 ExternalSystemConfiguration.create external_system_id: atos2.id,
   key: 'password', value: 'password', can_read: false
+ExternalSystemConfiguration.create external_system_id: ccd.id,
+  key: 'user_id', value: '22'
+ExternalSystemConfiguration.create external_system_id: ccd.id,
+  key: 'user_role', value: 'caseworker,caseworker-test,caseworker-employment-tribunal-manchester,caseworker-employment,caseworker-employment-tribunal-manchester-caseofficer,caseworker-publiclaw-localAuthority'
+ExternalSystemConfiguration.create external_system_id: ccd.id,
+  key: 'case_type_id', value: 'EmpTrib_MVP_1.0_Manc'
+
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -795,7 +795,9 @@ CREATE TABLE public.external_systems (
     office_codes integer[] DEFAULT '{}'::integer[],
     enabled boolean DEFAULT true,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    export_queue character varying,
+    export boolean DEFAULT false
 );
 
 
@@ -2179,6 +2181,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190312113307'),
 ('20190401204615'),
 ('20190401204745'),
-('20190524080441');
+('20190524080441'),
+('20190618145253'),
+('20190618153701');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -157,7 +157,8 @@ CREATE TABLE public.addresses (
     string character varying,
     post_code character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    country character varying
 );
 
 
@@ -2183,6 +2184,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190401204745'),
 ('20190524080441'),
 ('20190618145253'),
-('20190618153701');
+('20190618153701'),
+('20190705075853');
 
 

--- a/spec/factories/claimant_factory.rb
+++ b/spec/factories/claimant_factory.rb
@@ -13,7 +13,8 @@ FactoryBot.define do
         street: 'Petty France',
         locality: 'London',
         county: 'Greater London',
-        post_code: 'SW1H 9AJ'
+        post_code: 'SW1H 9AJ',
+        country: 'United Kingdom'
       address_telephone_number { '01234 567890' }
       mobile_number { '01234 098765' }
       email_address { 'test@digital.justice.gov.uk' }

--- a/spec/factories/external_system_factory.rb
+++ b/spec/factories/external_system_factory.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
       reference { "atos" }
       office_codes { [] }
       enabled { true }
+      export { false }
     end
 
     trait :minimal do
@@ -13,6 +14,16 @@ FactoryBot.define do
       sequence(:reference) { |idx| "reference#{idx}" }
       office_codes { [] }
       enabled { true }
+      export { false }
+    end
+    
+    trait :ccd do
+      name { "CCD" }
+      reference { "ccd_manchester" }
+      office_codes { [] }
+      enabled { true }
+      export { true }
+      export_queue { 'external_system_ccd' }
     end
 
     trait :for_all_offices do

--- a/spec/factories/json/json_address_factory.rb
+++ b/spec/factories/json/json_address_factory.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
       # Intentionally blank
     end
 
+    trait :in_uk do
+      country { "United Kingdom" }
+    end
+
     trait :invalid_keys do
       wrong_key { '21' }
       street { "downing_street" }

--- a/spec/factories/json/json_claim_factory.rb
+++ b/spec/factories/json/json_claim_factory.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
       end
       claim_traits { [:full] }
       primary_respondent_traits { [:full] }
-      primary_claimant_traits { [:mr_first_last] }
+      primary_claimant_traits { [:mr_first_last_in_uk] }
       secondary_claimant_traits { [:mr_first_last] }
       secondary_respondent_traits { [:full] }
       primary_representative_traits { [:full] }

--- a/spec/factories/json/json_claimant_factory.rb
+++ b/spec/factories/json/json_claimant_factory.rb
@@ -31,6 +31,21 @@ FactoryBot.define do
       special_needs { nil }
     end
 
+    trait :mr_first_last_in_uk do
+      title { 'Mr' }
+      first_name { 'First' }
+      last_name { 'Last' }
+      association :address_attributes, :petty_france_102, :in_uk, factory: :json_address_data
+      address_telephone_number { '01234 567890' }
+      mobile_number { '01234 098765' }
+      email_address { 'test@digital.justice.gov.uk' }
+      fax_number { nil }
+      contact_preference { 'Email' }
+      gender { 'Male' }
+      date_of_birth { '1982-11-21' }
+      special_needs { nil }
+    end
+
     trait :invalid_address_keys do
       association :address_attributes, :invalid_keys, factory: :json_address_data
     end

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,2 +1,2 @@
 require 'sidekiq/testing'
-Sidekiq::Testing.disable!
+Sidekiq::Testing.fake!


### PR DESCRIPTION



### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RST-1930


### Change description ###
This PR introduces a new gem called et_exporter which hooks itself in to the API's event system.
As standard, nothing will change - until you go into the admin and enable 'Export' for the externla system named 'CCD Manchester' (this is just for trial purposes and WILL go into production - as they need production data going into CCD fairly soon).


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
