### PR TITLE
Et exporter gem now adds content_type to the uploaded files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,4 +86,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'et_acas_api', path: 'vendor/gems/et_acas_api'
 
-gem 'et_exporter', git: 'https://github.com/hmcts/et_exporter_gem.git', tag: 'v0.2.1'
+gem 'et_exporter', git: 'https://github.com/hmcts/et_exporter_gem.git', tag: 'v0.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/hmcts/et_exporter_gem.git
-  revision: 3b6da47e1224d8cb3a64b21052f7c62731d2966c
-  tag: v0.2.1
+  revision: eef64f89cea7bf5c2e7b043be78b5c8c0feff944
+  tag: v0.3.1
   specs:
-    et_exporter (0.2.1)
+    et_exporter (0.3.1)
       jbuilder (~> 2.9, >= 2.9.1)
       pg
       rails (~> 5.2.3)

--- a/db/migrate/20190618153701_add_ccd_manchester_external_system.rb
+++ b/db/migrate/20190618153701_add_ccd_manchester_external_system.rb
@@ -2,7 +2,7 @@ class AddCcdManchesterExternalSystem < ActiveRecord::Migration[5.2]
   class ExternalSystem < ActiveRecord::Base
     self.table_name=:external_systems
   end
-  
+
   class ExternalSystemConfiguration < ActiveRecord::Base
     self.table_name=:external_system_configurations
   end
@@ -21,7 +21,7 @@ class AddCcdManchesterExternalSystem < ActiveRecord::Migration[5.2]
     ExternalSystemConfiguration.create external_system_id: ccd.id,
                                        key: 'user_role', value: 'caseworker,caseworker-test,caseworker-employment-tribunal-manchester,caseworker-employment,caseworker-employment-tribunal-manchester-caseofficer,caseworker-publiclaw-localAuthority'
     ExternalSystemConfiguration.create external_system_id: ccd.id,
-                                       key: 'case_type_id', value: 'EmpTrib_MVP_1.0_Manc'
+                                       key: 'case_type_id', value: 'Manchester_Dev'
   end
 
   def down

--- a/db/migrate/20190718073101_add_multiples_to_ccd_manchester_external_system.rb
+++ b/db/migrate/20190718073101_add_multiples_to_ccd_manchester_external_system.rb
@@ -11,7 +11,7 @@ class AddMultiplesToCcdManchesterExternalSystem < ActiveRecord::Migration[5.2]
     ccd = ExternalSystem.find_by(reference: 'ccd_manchester')
 
     ExternalSystemConfiguration.create external_system_id: ccd.id,
-      key: 'multiples_case_type_id', value: 'CCD_Bulk_Action_Manc_v3'
+      key: 'multiples_case_type_id', value: 'Manchester_Multiples_Dev'
   end
 
   def down

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,8 +54,8 @@ ExternalSystemConfiguration.create external_system_id: ccd.id,
 ExternalSystemConfiguration.create external_system_id: ccd.id,
   key: 'user_role', value: 'caseworker,caseworker-test,caseworker-employment-tribunal-manchester,caseworker-employment,caseworker-employment-tribunal-manchester-caseofficer,caseworker-publiclaw-localAuthority'
 ExternalSystemConfiguration.create external_system_id: ccd.id,
-  key: 'case_type_id', value: 'EmpTrib_MVP_1.0_Manc'
+  key: 'case_type_id', value: 'Manchester_Dev'
 ExternalSystemConfiguration.create external_system_id: ccd.id,
-  key: 'multiples_case_type_id', value: 'CCD_Bulk_Action_Manc_v3'
+  key: 'multiples_case_type_id', value: 'Manchester_Multiples_Dev'
 
 


### PR DESCRIPTION

### JIRA link (if applicable) ###

RST-1935

### Change description ###
This PR uses a later version of et exporter to add the content type to the exported data for all uploaded files


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
