### PR TITLE
RST-2425 - Bug fix - incorrect container used for et3 file upload

### DIFF
--- a/app/event_handlers/blob_built_handler.rb
+++ b/app/event_handlers/blob_built_handler.rb
@@ -10,7 +10,7 @@ class BlobBuiltHandler
 
   def build_service_for(blob)
     config = Rails.configuration.active_storage
-    blob.service = ActiveStorage::Service.configure config.service, config.service_configurations
+    blob.service = ActiveStorage::Service.configure "#{config.service}_direct_upload", config.service_configurations
   end
 
   def unsigned_url_for(blob)

--- a/config/database.yml
+++ b/config/database.yml
@@ -61,7 +61,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= ENV.fetch('DB_NAME', 'et_api_test') %>
+  database: 'et_api_test'
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/spec/requests/v2/build_blob_spec.rb
+++ b/spec/requests/v2/build_blob_spec.rb
@@ -92,6 +92,18 @@ RSpec.describe 'Build a blob using the configured cloud provider', type: :reques
       expect(json_response).to include meta: a_hash_including(cloud_provider: 'azure')
     end
 
+    it 'uses the correct direct container' do
+      # Arrange - build the data
+      json_factory = FactoryBot.build(:json_build_blob_command)
+      json_data = json_factory.to_json
+
+      # Act - Make the request
+      post '/api/v2/build_blob', params: json_data, headers: default_headers
+
+      # Assert - Make sure the data is in the response
+      expect(json_response).to include data: a_hash_including(url: match(/et\-api\-direct\-test\-container/))
+    end
+
     it 'returns exactly the same data if called with the same uuid' do
       # Arrange - build the data, call the endpoint for the first time then reset the session ready for the main call
       json_data = FactoryBot.build(:json_build_blob_command).to_json


### PR DESCRIPTION

### JIRA link (if applicable) ###

RST-2425

### Change description ###

RST-2425 - Bug fix - the blob built handler was incorrectly using the standard azure blob storage container instead of the direct upload one



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
