### PR TITLE
RST-1891 API Missing fields in pdf generation

### DIFF
--- a/app/services/build_claim_pdf_file_service.rb
+++ b/app/services/build_claim_pdf_file_service.rb
@@ -128,6 +128,7 @@ class BuildClaimPdfFileService # rubocop:disable Metrics/ClassLength
     apply_field result, ed[:average_hours_worked_per_week], :earnings_and_benefits, :average_weekly_hours
     apply_field result, ed[:benefit_details], :earnings_and_benefits, :benefits
     apply_field result, ed[:enrolled_in_pension_scheme], :earnings_and_benefits, :employers_pension_scheme
+    apply_field result, ed[:worked_notice_period_or_paid_in_lieu], :earnings_and_benefits, :paid_for_notice_period
     apply_field result, ed[:notice_pay_period_type] == 'monthly' ? ed[:notice_pay_period_count] : '', :earnings_and_benefits, :notice_period, :months
     apply_field result, ed[:notice_pay_period_type] == 'weekly' ? ed[:notice_pay_period_count] : '', :earnings_and_benefits, :notice_period, :weeks
     apply_field result, ed[:gross_pay]&.to_s, :earnings_and_benefits, :pay_before_tax, :amount

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_05_123156) do
+ActiveRecord::Schema.define(version: 2019_11_05_155140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - '${DB_PORT:-5432}:5432'
     networks:
       - api
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
   redis:
     image: redis
     ports:

--- a/spec/factories/json/json_claim_factory.rb
+++ b/spec/factories/json/json_claim_factory.rb
@@ -140,5 +140,29 @@ FactoryBot.define do
         }.stringify_keys
       end
     end
+
+    trait :worked_notice_period do
+      employment_details do
+        {
+          "start_date": "2009-11-18",
+          "end_date": nil,
+          "notice_period_end_date": nil,
+          "job_title": "agriculturist",
+          "average_hours_worked_per_week": 38.0,
+          "gross_pay": 3000,
+          "gross_pay_period_type": "monthly",
+          "net_pay": 2000,
+          "net_pay_period_type": "monthly",
+          "worked_notice_period_or_paid_in_lieu": true,
+          "notice_pay_period_type": 'months',
+          "notice_pay_period_count": 3.0,
+          "enrolled_in_pension_scheme": true,
+          "benefit_details": "Company car, private health care",
+          "found_new_job": nil,
+          "new_job_start_date": nil,
+          "new_job_gross_pay": nil
+        }.stringify_keys
+      end
+    end
   end
 end

--- a/spec/requests/v2/create_claim_spec.rb
+++ b/spec/requests/v2/create_claim_spec.rb
@@ -707,6 +707,20 @@ RSpec.describe 'Create Claim Request', type: :request do
       include_examples 'a claim exported to primary ATOS with a representative'
     end
 
+    context 'with json for single claimant, respondent and representative with worked notice period or paid in lieu' do
+      include_context 'with fake sidekiq'
+      include_context 'with setup for claims',
+        json_factory: -> { FactoryBot.build(:json_build_claim_commands, number_of_secondary_claimants: 0, number_of_secondary_respondents: 0, number_of_representatives: 1, has_pdf_file: false, claim_traits: [:full, :worked_notice_period]) }
+      include_context 'with background jobs running'
+      include_examples 'any claim variation'
+      include_examples 'a claim exported to primary ATOS'
+      include_examples 'a claim exported to primary ATOS with internally generated pdf'
+      include_examples 'a claim with provided reference number'
+      include_examples 'a claim exported to primary ATOS with single claimant'
+      include_examples 'a claim exported to primary ATOS with single respondent'
+      include_examples 'a claim exported to primary ATOS with a representative'
+    end
+
     context 'with json for single claimant, respondent and representative using welsh template' do
       include_context 'with fake sidekiq'
       include_context 'with setup for claims',

--- a/spec/support/messaging/cy.yml
+++ b/spec/support/messaging/cy.yml
@@ -511,6 +511,10 @@ et1-v1-cy:
           unselected_value: 'Off'
       paid_for_notice_period:
         field_name: '6.3 tick boxes'
+        select_values:
+          false: 'no'
+          true: 'yes'
+        unselected_value: 'Off'
       notice_period:
         weeks:
           field_name: '6.3 weeks'

--- a/spec/support/messaging/en.yml
+++ b/spec/support/messaging/en.yml
@@ -400,6 +400,10 @@ et1-v1-en:
           unselected_value: 'Off'
       paid_for_notice_period:
         field_name: '6.3 tick boxes'
+        select_values:
+          false: 'no'
+          true: 'yes'
+        unselected_value: 'Off'
       notice_period:
         weeks:
           field_name: '6.3 weeks'


### PR DESCRIPTION

### JIRA link (if applicable) ###
RST-1891


### Change description ###
This PR fixes a bug when the API generates its own PDF (will be enabled soon as other tickets need it) - the field for 'Worked notice period or paid in lieu' was not sent to the pdf


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
