### PR TITLE
RST-1439 ET1 (Azure) Move confirmation email into API

### DIFF
--- a/app/commands/build_claim_command.rb
+++ b/app/commands/build_claim_command.rb
@@ -18,8 +18,10 @@ class BuildClaimCommand < BaseCommand
   attribute :employment_details
   attribute :is_unfair_dismissal, :boolean
   attribute :pdf_template_reference, :string, default: 'et1-v1-en'
-
+  attribute :email_template_reference, :string, default: 'et1-v1-en'
+  attribute :confirmation_email_recipients, default: []
   validates :pdf_template_reference, inclusion: { in: ['et1-v1-en', 'et1-v1-cy'] }
+  validates :email_template_reference, inclusion: { in: ['et1-v1-en', 'et1-v1-cy'] }
 
   def initialize(*args, reference_service: ReferenceService, **kw_args)
     super(*args, **kw_args)

--- a/app/event_handlers/claim_email_handler.rb
+++ b/app/event_handlers/claim_email_handler.rb
@@ -1,0 +1,12 @@
+class ClaimEmailHandler
+  def handle(claim)
+    send_email(claim) unless claim.confirmation_email_recipients.empty?
+  end
+
+  private
+
+  def send_email(claim, template_reference: claim.email_template_reference)
+    office = OfficeService.lookup_by_case_number(claim.reference)
+    ClaimMailer.with(claim: claim, office: office, template_reference: template_reference).confirmation_email.deliver_now
+  end
+end

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -1,0 +1,19 @@
+class ClaimMailer < ApplicationMailer
+  def confirmation_email
+    @claim = params[:claim]
+    @office = params[:office]
+    @template_reference = params[:template_reference]
+    user_files.each do |user_file|
+      attachments.inline[user_file.filename] = user_file.file.download
+    end
+    mail to: @claim.confirmation_email_recipients,
+         template_path: 'mailers/claim_mailer',
+         template_name: "confirmation_email.#{@template_reference}"
+  end
+
+  private
+
+  def user_files
+    @claim.uploaded_files.not_hidden
+  end
+end

--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -5,4 +5,7 @@ class UploadedFile < ApplicationRecord
   has_one_attached :file
   include StoredFileDownload
   include StoredFileBase64Import
+
+  scope :not_hidden, -> { where('filename NOT LIKE ? AND filename NOT LIKE ? AND filename NOT LIKE ?', 'acas_%', 'et1_%.txt', 'et1a_%.txt') }
+  scope :not_pdf, -> { where('filename NOT LIKE ?', 'et1_%.pdf') }
 end

--- a/app/views/mailers/claim_mailer/confirmation_email.et1-v1-cy.html.erb
+++ b/app/views/mailers/claim_mailer/confirmation_email.et1-v1-cy.html.erb
@@ -1,0 +1,131 @@
+<% message.subject = "Tribiwnlys Cyflogaeth: hawliad wedi'i gyflwyno" %>
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+  <meta content="width=device-width" name="viewport"/>
+</head>
+<body>
+<table cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <td colspan="2" style="padding-left:60px; background-color:#000000; height:53px;">
+      <img src="https://s3-eu-west-1.amazonaws.com/mojet-emails/govuk_logotype_email.png"/></td>
+  </tr>
+  <tr>
+    <td width="8%"><p>&nbsp;</p></td>
+    <td>
+      <table style="max-width:525px;" width="100%">
+        <tr>
+          <td style="padding-bottom:30px;">
+            <img src="https://s3-eu-west-1.amazonaws.com/mojet-emails/moj_logotype_email.png"/></td>
+        </tr>
+        <tr>
+          <td style="padding-left:20px; background-color:#28a197; color: #ffffff">
+            <p style="font-family:arial; font-size:19px; margin:20px 0px 5px;">Claim Eich rhif hawliad</p>
+            <p style="font-family:arial; font-size:40px; margin:0px 0px 20px; font-weight:bold;"><%= @claim.submission_reference %></p>
+          </td>
+        </tr>
+        <tr>
+          <td><p style="font-family:arial; font-size:19px"><%= @claim.primary_claimant.first_name %> <%= @claim.primary_claimant.last_name %></p></td>
+        </tr>
+        <tr>
+          <td><p style="font-family:arial; font-size:19px">Diolch am gyflwyno eich hawliad i dribiwnlys cyflogaeth.
+            tribunal.</p>
+            <p style="font-family:arial; font-size:19px; font-weight:bold; margin-top:50px;">Beth sy'n digwydd nesaf</p>
+            <ol>
+              <li style="font-family:arial; font-size:19px; line-height:26px;">
+                <p>Byddwn yn cysylltu â chi unwaith y byddwn wedi anfon eich hawliad at yr atebydd i egluro beth fydd yn digwydd nesaf. Ar hyn o bryd, mae’n cymryd oddeutu 25 diwrnod.</p>
+              </li>
+              <li style="font-family:arial; font-size:19px; line-height:26px;">
+                <p>Unwaith y byddwn wedi anfon eich hawliad atynt, mae gan yr atebydd 28 diwrnod i ymateb.
+                </p></li>
+            </ol>
+            <p style="font-family:arial; font-size:19px; font-weight:bold; margin-top:50px;">Manylion cyflwyno</p>
+            <table style="width:550px;padding-bottom:30px;">
+              <tr>
+                <td colspan="2">
+                  <hr style="border:0px; border-top:1px solid #bfc1c3; margin:0px;"/>
+                </td>
+              </tr>
+              <tr>
+                <td valign="top" width="185">
+                  <p style="font-family:arial; font-size:16px; color:#6F777B;">Hawliad wedi'i gwblhau:</p></td>
+                <td valign="top"><p style="font-family:arial; font-size:16px;">Gweler y PDF sydd ynghlwm</p></td>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <hr style="border:0px; border-top:1px solid #bfc1c3; margin:0px;"/>
+                </td>
+              </tr>
+              <tr>
+                <td valign="top" width="185">
+                  <p style="font-family:arial; font-size:16px; color:#6F777B;">Hawliad wedi'i gyflwyno:</p></td>
+                <td valign="top"><p style="font-family:arial; font-size:16px;">Cyflwynwyd ar <%= I18n.l @claim.date_of_receipt, format: '%d %B %Y', locale: 'cy' %></p></td>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <hr style="border:0px; border-top:1px solid #bfc1c3; margin:0px;"/>
+                </td>
+              </tr>
+              <tr>
+                <td valign="top" width="185">
+                  <p style="font-family:arial; font-size:16px; color:#6F777B;">Swyddfa tribiwnlys:</p></td>
+                <td valign="top">
+                  <p style="font-family:arial; font-size:16px;">Cymru, Tribiwnlys Cyflogaeth, 3ydd Llawr, Llys Ynadon Caerdydd a’r Fro, Plas Fitzalan, Caerdydd, CF24 0RA</p>
+                </td>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <hr style="border:0px; border-top:1px solid #bfc1c3; margin:0px;"/>
+                </td>
+              </tr>
+              <tr>
+                <td valign="top" width="185">
+                  <p style="font-family:arial; font-size:16px; color:#6F777B;">Dogfennau ychwanegol:</p></td>
+                <% if @claim.uploaded_files.not_hidden.not_pdf.empty? %>
+                  <td valign="top"><p style="font-family:arial; font-size:16px;">Dim</p></td>
+                <% else %>
+                  <td valign="top">
+                    <% @claim.uploaded_files.not_hidden.not_pdf.each do |file| %>
+                    <p style="font-family:arial; font-size:16px;"><%= file.filename %></p>
+                    <% end %>
+                  </td>
+                <% end %>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <hr style="border:0px; border-top:1px solid #bfc1c3; margin:0px;"/>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td><p style="font-family:arial; font-size:19px">
+            <a href="https://www.gov.uk/done/employment-tribunals-make-a-claim">Mae eich adborth</a> yn ein helpu i wella'r gwasanaeth hwn.
+          </p></td>
+        </tr>
+        <tr>
+          <td><p style="font-family:arial; font-size:19px">
+            Helpwch ni i gadw cofnodion cywir . Llenwch ein <a href="https://employmenttribunals.service.gov.uk/en/apply/diversity">holiadur monitro amrywiaeth</a>.
+          </p></td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2">
+      <table style="width:100%; padding:20px 0px 20px 60px; background-color:#dee0e2; height:100px; border-top:1px #a1acb2 solid;">
+        <tbody>
+        <tr>
+          <td><p style="font-family:arial; font-size:16px; padding-bottom:15px;">
+            <a href="http://www.justice.gov.uk/contacts/hmcts/tribunals/employment" style="color:#6F777B;" target="_blank">CCysylltu â ni</a></p></td>
+          <td><img src="https://s3-eu-west-1.amazonaws.com/mojet-emails/govuk_crest_email.png"/></td>
+        </tr>
+        </tbody>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/app/views/mailers/claim_mailer/confirmation_email.et1-v1-cy.text.erb
+++ b/app/views/mailers/claim_mailer/confirmation_email.et1-v1-cy.text.erb
@@ -1,0 +1,36 @@
+<% message.subject = "Tribiwnlys Cyflogaeth: hawliad wedi'i gyflwyno" %>
+Eich rhif hawliad: <%= @claim.submission_reference %>
+
+<%= @claim.primary_claimant.first_name %> <%= @claim.primary_claimant.last_name %>
+Diolch am gyflwyno eich hawliad i dribiwnlys cyflogaeth.
+==================================================
+
+BETH SY'N DIGWYDD NESAF
+
+Byddwn yn cysylltu â chi unwaith y byddwn wedi anfon eich hawliad at yr atebydd i egluro beth fydd yn digwydd nesaf. Ar hyn o bryd, mae’n cymryd oddeutu 25 diwrnod.
+Unwaith y byddwn wedi anfon eich hawliad atynt, mae gan yr atebydd 28 diwrnod i ymateb.
+
+==================================================
+
+MANYLION CYFLWYNO
+
+Hawliad wedi'i gwblhau:       Gweler y PDF sydd ynghlwm
+Hawliad wedi'i gyflwyno:      Cyflwynwyd ar <%= I18n.l @claim.date_of_receipt, format: '%d %B %Y', locale: 'cy' %>
+Swyddfa tribiwnlys:           Cymru, Tribiwnlys Cyflogaeth, 3ydd Llawr, Llys Ynadon Caerdydd a’r Fro, Plas Fitzalan, Caerdydd, CF24 0RA
+Dogfennau ychwanegol:         <%- if @claim.uploaded_files.not_hidden.not_pdf.empty? %>
+Dim
+<%- else %>
+<%- @claim.uploaded_files.not_hidden.not_pdf.each_with_index do |file, idx| %>
+<%= ' ' * 30 unless idx == 0 %><%= file.filename %>
+<% end %>
+<% end %>
+
+==================================================
+
+Mae eich adborth yn ein helpu i wella'r gwasanaeth hwn:
+https://www.gov.uk/done/employment-tribunals-make-a-claim
+
+Helpwch ni i gadw cofnodion cywir . Llenwch ein holiadur monitro amrywiaeth.
+https://employmenttribunals.service.gov.uk/en/apply/diversity
+
+Cysylltu â ni: http://www.justice.gov.uk/contacts/hmcts/tribunals/employment

--- a/app/views/mailers/claim_mailer/confirmation_email.et1-v1-en.html.erb
+++ b/app/views/mailers/claim_mailer/confirmation_email.et1-v1-en.html.erb
@@ -1,0 +1,134 @@
+<% message.subject = 'Employment tribunal: claim submitted' %>
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="text/html; charset=UTF-8" http-equiv="Content-Type"/>
+  <meta content="width=device-width" name="viewport"/>
+</head>
+<body>
+<table cellpadding="0" cellspacing="0" width="100%">
+  <tr>
+    <td colspan="2" style="padding-left:60px; background-color:#000000; height:53px;">
+      <img src="https://s3-eu-west-1.amazonaws.com/mojet-emails/govuk_logotype_email.png"/></td>
+  </tr>
+  <tr>
+    <td width="8%"><p>&nbsp;</p></td>
+    <td>
+      <table style="max-width:525px;" width="100%">
+        <tr>
+          <td style="padding-bottom:30px;">
+            <img src="https://s3-eu-west-1.amazonaws.com/mojet-emails/moj_logotype_email.png"/></td>
+        </tr>
+        <tr>
+          <td style="padding-left:20px; background-color:#28a197; color: #ffffff">
+            <p style="font-family:arial; font-size:19px; margin:20px 0px 5px;">Claim number</p>
+            <p style="font-family:arial; font-size:40px; margin:0px 0px 20px; font-weight:bold;"><%= @claim.submission_reference %></p>
+          </td>
+        </tr>
+        <tr>
+          <td><p style="font-family:arial; font-size:19px"><%= @claim.primary_claimant.first_name %> <%= @claim.primary_claimant.last_name %></p></td>
+        </tr>
+        <tr>
+          <td><p style="font-family:arial; font-size:19px">Thank you for submitting your claim to an employment
+            tribunal.</p>
+            <p style="font-family:arial; font-size:19px; font-weight:bold; margin-top:50px;">What happens next</p>
+            <ol>
+              <li style="font-family:arial; font-size:19px; line-height:26px;">
+                <p>We&#39;ll contact you once we have sent your claim to the respondent and explain what happens next.
+                  At present, this is taking us an average of 25 days.
+                </p></li>
+              <li style="font-family:arial; font-size:19px; line-height:26px;">
+                <p>Once we have sent them your claim, the respondent has 28 days to reply.
+                </p></li>
+            </ol>
+            <p style="font-family:arial; font-size:19px; font-weight:bold; margin-top:50px;">Submission details</p>
+            <table style="width:550px;padding-bottom:30px;">
+              <tr>
+                <td colspan="2">
+                  <hr style="border:0px; border-top:1px solid #bfc1c3; margin:0px;"/>
+                </td>
+              </tr>
+              <tr>
+                <td valign="top" width="185">
+                  <p style="font-family:arial; font-size:16px; color:#6F777B;">Claim completed:</p></td>
+                <td valign="top"><p style="font-family:arial; font-size:16px;">See attached PDF</p></td>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <hr style="border:0px; border-top:1px solid #bfc1c3; margin:0px;"/>
+                </td>
+              </tr>
+              <tr>
+                <td valign="top" width="185">
+                  <p style="font-family:arial; font-size:16px; color:#6F777B;">Claim submitted:</p></td>
+                <td valign="top"><p style="font-family:arial; font-size:16px;">Submitted <%= @claim.date_of_receipt.strftime('%d %B %Y') %></p></td>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <hr style="border:0px; border-top:1px solid #bfc1c3; margin:0px;"/>
+                </td>
+              </tr>
+              <tr>
+                <td valign="top" width="185">
+                  <p style="font-family:arial; font-size:16px; color:#6F777B;">Tribunal office:</p></td>
+                <td valign="top">
+                  <p style="font-family:arial; font-size:16px;"><%= @office.name %>, <%= @office.email %>, <%= @office.telephone %></p>
+                </td>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <hr style="border:0px; border-top:1px solid #bfc1c3; margin:0px;"/>
+                </td>
+              </tr>
+              <tr>
+                <td valign="top" width="185">
+                  <p style="font-family:arial; font-size:16px; color:#6F777B;">Additional documents:</p></td>
+                <% if @claim.uploaded_files.not_hidden.not_pdf.empty? %>
+                  <td valign="top"><p style="font-family:arial; font-size:16px;">None</p></td>
+                <% else %>
+                  <td valign="top">
+                    <% @claim.uploaded_files.not_hidden.not_pdf.each do |file| %>
+                    <p style="font-family:arial; font-size:16px;"><%= file.filename %></p>
+                    <% end %>
+                  </td>
+                <% end %>
+              </tr>
+              <tr>
+                <td colspan="2">
+                  <hr style="border:0px; border-top:1px solid #bfc1c3; margin:0px;"/>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td><p style="font-family:arial; font-size:19px">
+            <a href="https://www.gov.uk/done/employment-tribunals-make-a-claim">Your feedback</a> helps us improve this
+            service.
+          </p></td>
+        </tr>
+        <tr>
+          <td><p style="font-family:arial; font-size:19px">Help us keep track. Complete our
+            <a href="https://employmenttribunals.service.gov.uk/en/apply/diversity">diversity monitoring questionnaire</a>.
+          </p></td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+  <tr>
+    <td colspan="2">
+      <table style="width:100%; padding:20px 0px 20px 60px; background-color:#dee0e2; height:100px; border-top:1px #a1acb2 solid;">
+        <tbody>
+        <tr>
+          <td><p style="font-family:arial; font-size:16px; padding-bottom:15px;">
+            <a href="http://www.justice.gov.uk/contacts/hmcts/tribunals/employment" style="color:#6F777B;" target="_blank">Contact
+              us</a></p></td>
+          <td><img src="https://s3-eu-west-1.amazonaws.com/mojet-emails/govuk_crest_email.png"/></td>
+        </tr>
+        </tbody>
+      </table>
+    </td>
+  </tr>
+</table>
+</body>
+</html>

--- a/app/views/mailers/claim_mailer/confirmation_email.et1-v1-en.text.erb
+++ b/app/views/mailers/claim_mailer/confirmation_email.et1-v1-en.text.erb
@@ -1,0 +1,37 @@
+<% message.subject = 'Employment tribunal: claim submitted' %>
+Claim number: <%= @claim.submission_reference %>
+
+<%= @claim.primary_claimant.first_name %> <%= @claim.primary_claimant.last_name %>
+Thank you for submitting your claim to an employment tribunal.
+==================================================
+
+WHAT HAPPENS NEXT
+
+We'll contact you once we have sent your claim to the respondent and explain what happens next.
+At present, this is taking us an average of 25 days.
+Once we have sent them your claim, the respondent has 28 days to reply.
+
+==================================================
+
+SUBMISSION DETAILS
+
+Claim completed:       See attached PDF
+Claim submitted:       Submitted <%= @claim.date_of_receipt.strftime('%d %B %Y') %>
+Tribunal office:       <%= @office.name %>, <%= @office.email %>, <%= @office.telephone %>
+Additional documents:  <%- if @claim.uploaded_files.not_hidden.not_pdf.empty? %>
+None
+<%- else %>
+<%- @claim.uploaded_files.not_hidden.not_pdf.each_with_index do |file, idx| %>
+<%= ' ' * 23 unless idx == 0 %><%= file.filename %>
+<% end %>
+<% end %>
+
+==================================================
+
+Your feedback helps us improve this service:
+https://www.gov.uk/done/employment-tribunals-make-a-claim
+
+Help us keep track. Complete our diversity monitoring questionnaire.
+https://employmenttribunals.service.gov.uk/en/apply/diversity
+
+Contact us: http://www.justice.gov.uk/contacts/hmcts/tribunals/employment

--- a/config/initializers/event_handlers.rb
+++ b/config/initializers/event_handlers.rb
@@ -7,6 +7,7 @@ Rails.application.config.after_initialize do |app|
   app.event_service.subscribe('ClaimImported', PrepareImportedClaimHandler, async: true, in_process: false)
   app.event_service.subscribe('ClaimExported', ClaimExportedHandler, async: true, in_process: false)
   app.event_service.subscribe('ClaimPreparedForAtosExport', ClaimExportHandler, async: false, in_process: true)
+  app.event_service.subscribe('ClaimPrepared', ClaimEmailHandler, async: true, in_process: false)
   app.event_service.subscribe('BlobBuilt', BlobBuiltHandler, async: false, in_process: true)
   app.event_service.subscribe('ReferenceCreated', ReferenceCreatedHandler, async: false, in_process: true)
   app.event_service.subscribe('FeedbackCreated', FeedbackEmailHandler, async: true, in_process: false)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,0 +1,205 @@
+
+cy:
+  date:
+    abbr_day_names:
+    - Sul
+    - Llun
+    - Maw
+    - Mer
+    - Iau
+    - Gwe
+    - Sad
+    abbr_month_names:
+    -
+    - Ion
+    - Chw
+    - Maw
+    - Ebr
+    - Mai
+    - Meh
+    - Gor
+    - Awst
+    - Med
+    - Hyd
+    - Tach
+    - Rha
+    day_names:
+    - Dydd Sul
+    - Dydd Llun
+    - Dydd Mawrth
+    - Dydd Mercher
+    - Dydd Iau
+    - Dydd Gwener
+    - Dydd Sadwrn
+    formats:
+      default: "%d-%m-%Y"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    -
+    - Ionawr
+    - Chwefror
+    - Mawrth
+    - Ebrill
+    - Mai
+    - Mehefin
+    - Gorffennaf
+    - Awst
+    - Medi
+    - Hydref
+    - Tachwedd
+    - Rhagfyr
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        zero: tua %{count} awr
+        one: tuag awr
+        two: tua %{count} awr
+        few: tua %{count} awr
+        many: tua %{count} awr
+        other: tua %{count} awr
+      about_x_months:
+        zero: tua %{count} mis
+        one: tua mis
+        two: tua %{count} mis
+        few: tua %{count} mis
+        many: tua %{count} mis
+        other: tua %{count} mis
+      about_x_years:
+        zero: tua %{count} blynedd
+        one: tua blwyddyn
+        two: tua %{count} blynedd
+        few: tua %{count} blynedd
+        many: tua %{count} blynedd
+        other: tua %{count} blynedd
+      almost_x_years:
+        zero: bron yn %{count} blynedd
+        one: bron yn flwyddyn
+        two: bron yn %{count} blynedd
+        few: bron yn %{count} blynedd
+        many: bron yn %{count} blynedd
+        other: bron yn %{count} blynedd
+      half_a_minute: hanner munud
+      less_than_x_minutes:
+        zero: llai na %{count} munud
+        one: llai na munud
+        two: llai na %{count} munud
+        few: llai na %{count} munud
+        many: llai na %{count} munud
+        other: llai na %{count} munud
+      less_than_x_seconds:
+        zero: llai na %{count} eiliad
+        one: llai nag eiliad
+        two: llai na %{count} eiliad
+        few: llai na %{count} eiliad
+        many: llai na %{count} eiliad
+        other: llai na %{count} eiliad
+      over_x_years:
+        zero: dros %{count} blynedd
+        one: dros flwyddyn
+        two: dros %{count} blynedd
+        few: dros %{count} blynedd
+        many: dros %{count} blynedd
+        other: dros %{count} blynedd
+      x_days:
+        zero: "%{count} diwrnod"
+        one: 1 diwrnod
+        two: "%{count} diwrnod"
+        few: "%{count} diwrnod"
+        many: "%{count} diwrnod"
+        other: "%{count} diwrnod"
+      x_minutes:
+        zero: "%{count} o funudau"
+        one: 1 munud
+        two: "%{count} o funudau"
+        few: "%{count} o funudau"
+        many: "%{count} o funudau"
+        other: "%{count} o funudau"
+      x_months:
+        zero: "%{count} mis"
+        one: 1 mis
+        two: "%{count} mis"
+        few: "%{count} mis"
+        many: "%{count} mis"
+        other: "%{count} mis"
+      x_seconds:
+        zero: "%{count} o eiliadau"
+        one: 1 eiliad
+        two: "%{count} o eiliadau"
+        few: "%{count} o eiliadau"
+        many: "%{count} o eiliadau"
+        other: "%{count} o eiliadau"
+    prompts:
+      day: Diwrnod
+      hour: Awr
+      minute: Munud
+      month: Mis
+      second: Eiliad
+      year: Blwyddyn
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "£"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Biliwn
+          million: Miliwn
+          quadrillion: Cwadriliwn
+          thousand: Mil
+          trillion: Triliwn
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            zero: Bytes
+            one: Byte
+            two: Bytes
+            few: Bytes
+            many: Bytes
+            other: Bytes
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", a "
+      two_words_connector: " a "
+      words_connector: ", "
+  time:
+    am: yb
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: yh

--- a/db/migrate/20200312133758_add_email_template_reference_to_claims.rb
+++ b/db/migrate/20200312133758_add_email_template_reference_to_claims.rb
@@ -1,0 +1,5 @@
+class AddEmailTemplateReferenceToClaims < ActiveRecord::Migration[6.0]
+  def change
+    add_column :claims, :email_template_reference, :string, null: false, default: 'et1-v1-en'
+  end
+end

--- a/db/migrate/20200312134523_add_confirmation_email_recipients_to_claims.rb
+++ b/db/migrate/20200312134523_add_confirmation_email_recipients_to_claims.rb
@@ -1,0 +1,5 @@
+class AddConfirmationEmailRecipientsToClaims < ActiveRecord::Migration[6.0]
+  def change
+    add_column :claims, :confirmation_email_recipients, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_05_155140) do
+ActiveRecord::Schema.define(version: 2020_03_12_134523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -195,6 +195,8 @@ ActiveRecord::Schema.define(version: 2019_11_05_155140) do
     t.bigint "primary_respondent_id"
     t.bigint "primary_representative_id"
     t.string "pdf_template_reference", null: false
+    t.string "email_template_reference", default: "et1-v1-en", null: false
+    t.string "confirmation_email_recipients", default: [], array: true
     t.index ["primary_claimant_id"], name: "index_claims_on_primary_claimant_id"
     t.index ["primary_representative_id"], name: "index_claims_on_primary_representative_id"
     t.index ["primary_respondent_id"], name: "index_claims_on_primary_respondent_id"

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - '${DB_PORT:-5432}:5432'
     networks:
       - api
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
   redis:
     image: redis
     ports:

--- a/spec/factories/json/json_claim_factory.rb
+++ b/spec/factories/json/json_claim_factory.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
       secondary_respondent_traits { [:full] }
       primary_representative_traits { [:full] }
       pdf_template { 'et1-v1-en' }
+      email_template { 'et1-v1-en' }
     end
 
     uuid { SecureRandom.uuid }
@@ -72,9 +73,13 @@ FactoryBot.define do
       pdf_template { 'et1-v1-cy' }
     end
 
+    trait :with_welsh_email do
+      email_template { 'et1-v1-cy' }
+    end
+
     after(:build) do |doc, evaluator|
       evaluator.instance_eval do
-        doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildClaim', data: build(:json_claim_data, *claim_traits, pdf_template_reference: pdf_template, reference: reference, case_type: case_type))
+        doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildClaim', data: build(:json_claim_data, *claim_traits, pdf_template_reference: pdf_template, email_template_reference: email_template, reference: reference, case_type: case_type))
         doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildPrimaryRespondent', data: build(:json_respondent_data, *primary_respondent_traits))
         doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildPrimaryClaimant', data: build(:json_claimant_data, *primary_claimant_traits))
         doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildSecondaryClaimants', data: build_list(:json_claimant_data, number_of_secondary_claimants, *secondary_claimant_traits))
@@ -113,6 +118,8 @@ FactoryBot.define do
       miscellaneous_information { '' }
       is_unfair_dismissal { false }
       pdf_template_reference { "et1-v1-en" }
+      email_template_reference { "et1-v1-en" }
+      confirmation_email_recipients { ['confirmation_recipient@digital.justice.gov.uk'] }
     end
     trait :full do
       minimal

--- a/spec/support/email_support/email_objects/new_claim_email_cy_html.rb
+++ b/spec/support/email_support/email_objects/new_claim_email_cy_html.rb
@@ -1,0 +1,24 @@
+require_relative './base'
+require_relative '../../helpers/office_helper'
+module EtApi
+  module Test
+    module EmailObjects
+      class NewClaimEmailCyHtml < NewClaimEmailEnHtml
+        def self.find(repo: ActionMailer::Base.deliveries, reference:)
+          instances = repo.map { |mail| new(mail) }
+          instances.detect { |instance| instance.has_correct_subject? && instance.has_reference_element?(reference) }
+        end
+
+        def self.template_reference
+          'et1-v1-cy'
+        end
+
+        define_site_prism_elements(template_reference)
+
+        def assert_office_information(office)
+          expect(office_information).to have_office_summary(text: "Cymru, Tribiwnlys Cyflogaeth, 3ydd Llawr, Llys Ynadon Caerdydd a’r Fro, Plas Fitzalan, Caerdydd, CF24 0RA")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/email_support/email_objects/new_claim_email_cy_text.rb
+++ b/spec/support/email_support/email_objects/new_claim_email_cy_text.rb
@@ -1,0 +1,25 @@
+require_relative './base'
+require_relative '../../helpers/office_helper'
+require_relative './new_claim_email_en_text'
+module EtApi
+  module Test
+    module EmailObjects
+      class NewClaimEmailCyText < NewClaimEmailEnText
+        def self.find(repo: ActionMailer::Base.deliveries, reference:)
+          instances = repo.map { |delivery| new(delivery) }
+          instances.detect { |instance| instance.has_correct_subject? && instance.has_reference?(reference) }
+        end
+
+        def self.template_reference
+          'et1-v1-cy'
+        end
+
+        def assert_office_information(office)
+          return if lines.any? { |l| l.strip =~ %r{Swyddfa tribiwnlys: \s*Cymru, Tribiwnlys Cyflogaeth, 3ydd Llawr, Llys Ynadon Caerdydd a’r Fro, Plas Fitzalan, Caerdydd, CF24 0RA} }
+
+          raise Capybara::ElementNotFound.new("The office information line was not found for #{office.name}")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/email_support/email_objects/new_claim_email_en_html.rb
+++ b/spec/support/email_support/email_objects/new_claim_email_en_html.rb
@@ -1,0 +1,188 @@
+require_relative './base'
+require_relative '../../helpers/office_helper'
+module EtApi
+  module Test
+    module EmailObjects
+      class NewClaimEmailEnHtml < SitePrism::Page
+        include RSpec::Matchers
+        include EtApi::Test::OfficeHelper
+        include EtApi::Test::ClaimHelper
+        include EtApi::Test::I18n
+
+        def self.find(repo: ActionMailer::Base.deliveries, reference:)
+          instances = repo.map { |mail| new(mail) }
+          instances.detect { |instance| instance.has_correct_subject? && instance.has_reference_element?(reference) }
+        end
+
+        def self.template_reference
+          'et1-v1-en'
+        end
+
+        def initialize(mail)
+          self.mail = mail
+          multipart = mail.parts.detect { |p| p.content_type =~ %r{multipart\/alternative} }
+          part = multipart.parts.detect { |p| p.content_type =~ %r{text\/html} }
+          body = part.nil? ? '' : part.body.to_s
+          load(body)
+        end
+
+        def template_reference
+          self.class.template_reference
+        end
+
+        def has_reference_element?(reference)
+          submission_reference = claim_submission_reference_for(reference: reference)
+          claim_number.has_value?(text: submission_reference)
+        end
+
+        def has_correct_content_for?(input_data, primary_claimant_data, claimants_file, claim_details_file, reference:) # rubocop:disable Naming/PredicateName
+          office = office_for(case_number: reference)
+          aggregate_failures 'validating content' do
+            assert_reference_element(claim_submission_reference_for(reference: reference))
+            expect(has_correct_subject?).to be true
+            expect(assert_correct_to_address_for?(input_data)).to be true
+            assert_office_information(office)
+            assert_submission_date
+            assert_claimant(primary_claimant_data)
+            assert_submission(primary_claimant_data, claimants_file, claim_details_file)
+            expect(attached_pdf_for(primary_claimant_data: primary_claimant_data)).to be_present
+            if claimants_file.present?
+              expect(attached_claimants_file_for(primary_claimant_data: primary_claimant_data)).to be_present
+            else
+              expect(attached_claimants_file_for(primary_claimant_data: primary_claimant_data)).not_to be_present
+            end
+            if claim_details_file.present?
+              expect(attached_info_file_for(primary_claimant_data: primary_claimant_data)).to be_present
+            else
+              expect(attached_info_file_for(primary_claimant_data: primary_claimant_data)).not_to be_present
+            end
+          end
+          true
+        end
+
+        def has_correct_subject? # rubocop:disable Naming/PredicateName
+          mail.subject == t('claim_email.subject', locale: template_reference)
+        end
+
+        private
+
+        def self.define_site_prism_elements(template_reference)
+          section :claim_number, :xpath, XPath.generate {|x| x.descendant(:td)[x.child(:p)[x.string.n.is(t('claim_email.reference', locale: template_reference))]]} do
+            element :value, :xpath, XPath.generate {|x| x.child(:p)[2]}
+          end
+
+          section :submission_info, :xpath, XPath.generate {|x| x.descendant(:tr)[x.child(:td)[x.child(:p)[x.string.n.is(t('claim_email.submission_info', locale: template_reference))]]]} do
+            element :submission_date, :xpath, XPath.generate {|x| x.child(:td)[2].child(:p)}
+          end
+
+          section :office_information, :xpath, XPath.generate {|x| x.descendant(:tr)[x.child(:td)[x.child(:p)[x.string.n.is(t('claim_email.tribunal_office', locale: template_reference))]]] } do
+            element :office_summary, :xpath, XPath.generate {|x| x.child(:td)[2].child(:p)  }
+          end
+
+          element :claimant_full_name, :xpath, XPath.generate {|x| x.descendant(:tr).child(:td)[1].child(:p)}
+
+          section :submission, :xpath, XPath.generate {|x| x.descendant(:tr)[x.child(:td)[1][x.child(:p)[x.string.n.is(t('claim_email.thank_you', locale: template_reference))]]]} do
+            section :what_happens_next, :xpath, XPath.generate {|x| x.child(:td)[1]} do
+              include RSpec::Matchers
+              include EtApi::Test::I18n
+              def assert_valid(template_reference:)
+                expect(root_element).to have_content(t('claim_email.next_steps.well_contact_you', locale: template_reference))
+                expect(root_element).to have_content(t('claim_email.next_steps.once_sent_claim', locale: template_reference))
+              end
+            end
+
+            section :submission_details, :xpath, XPath.generate {|x| x.child(:td)[1]} do
+              include RSpec::Matchers
+              include EtApi::Test::I18n
+
+              def assert_valid(primary_claimant_data, claimants_file, claim_details_file, template_reference:)
+                expect(root_element).to have_content(t('claim_email.submission_details', locale: template_reference))
+                expect(root_element).to have_content(t('claim_email.claim_completed', locale: template_reference))
+                expect(root_element).to have_content(t('claim_email.see_attached_pdf', locale: template_reference))
+                expect(root_element).to have_content(t('claim_email.claim_submitted', locale: template_reference))
+                now = Time.now
+                expect(root_element).to have_content(t('claim_email.submitted_at', date: l(now, format: '%d %B %Y', locale: template_reference.split('-').last), locale: template_reference)).or have_content(t('claim_email.submitted_at', date: l((now - 1.minute), format: '%d %B %Y', locale: template_reference.split('-').last), locale: template_reference))
+                if claimants_file.present?
+                  expect(root_element).to have_content "et1a_#{scrubber primary_claimant_data.first_name}_#{scrubber primary_claimant_data.last_name}.csv"
+                else
+                  expect(root_element).not_to have_content "et1a_#{scrubber primary_claimant_data.first_name}_#{scrubber primary_claimant_data.last_name}.csv"
+                end
+
+                if claim_details_file.present?
+                  expect(root_element).to have_content("et1_attachment_#{scrubber primary_claimant_data.first_name}_#{scrubber primary_claimant_data.last_name}.rtf")
+                else
+                  expect(root_element).not_to have_content("et1_attachment_#{scrubber primary_claimant_data.first_name}_#{scrubber primary_claimant_data.last_name}.rtf")
+                end
+              end
+
+              private
+
+              def scrubber(text)
+                text.gsub(/\s/, '_').gsub(/\W/, '')
+              end
+            end
+
+
+          end
+        end
+
+        define_site_prism_elements(template_reference)
+
+        def assert_correct_to_address_for?(input_data) # rubocop:disable Naming/PredicateName
+          expect(mail.to).to match_array(input_data.confirmation_email_recipients)
+        end
+
+        def assert_reference_element(reference)
+          expect(claim_number).to have_value(text: reference)
+        end
+
+        def assert_submission_date_element(submission_date)
+          expect(submission_info).to have_submission_date(text: t('claim_email.submission_date', locale: template_reference, date: submission_date))
+        end
+
+        def has_submission_date_element?(submission_date)
+          submission_info.has_submission_date?(text: t('claim_email.submission_date', locale: template_reference, date: submission_date))
+        end
+
+        def assert_submission_date
+          now = Time.zone.now
+
+          return if has_submission_date_element?(l now, format: '%d %B %Y', locale: template_reference.split('-').last)
+          assert_submission_date_element(l (now - 1.minute), format: '%d %B %Y', locale: template_reference.split('-').last)
+        end
+
+        def assert_office_information(office)
+          expect(office_information).to have_office_summary(text: "#{office.name}, #{office.email}, #{office.telephone}")
+        end
+
+        def assert_claimant(primary_claimant_data)
+          expect(self).to have_claimant_full_name(text: "#{primary_claimant_data.first_name} #{primary_claimant_data.last_name}")
+        end
+
+        def assert_submission(claimant, claimants_file, claim_details_file)
+          expect(submission).to have_what_happens_next
+          submission.what_happens_next.assert_valid(template_reference: template_reference)
+          submission.submission_details.assert_valid(claimant, claimants_file, claim_details_file, template_reference: template_reference)
+        end
+
+        def attached_pdf_for(primary_claimant_data:)
+          mail.parts.attachments.detect { |a| a.filename == "et1_#{scrubber primary_claimant_data.first_name.downcase}_#{scrubber primary_claimant_data.last_name.downcase}.pdf" }
+        end
+
+        def attached_claimants_file_for(primary_claimant_data:)
+          mail.parts.attachments.detect { |a| a.filename == "et1a_#{scrubber primary_claimant_data.first_name}_#{scrubber primary_claimant_data.last_name}.csv" }
+        end
+
+        def attached_info_file_for(primary_claimant_data:)
+          mail.parts.attachments.detect { |a| a.filename.end_with? '.rtf' }
+        end
+
+        attr_accessor :mail
+
+        def scrubber(text)
+          text.gsub(/\s/, '_').gsub(/\W/, '')
+        end
+      end
+    end
+  end
+end

--- a/spec/support/email_support/email_objects/new_claim_email_en_text.rb
+++ b/spec/support/email_support/email_objects/new_claim_email_en_text.rb
@@ -1,0 +1,161 @@
+require_relative './base'
+require_relative '../../helpers/office_helper'
+module EtApi
+  module Test
+    module EmailObjects
+      class NewClaimEmailEnText < Base
+        include RSpec::Matchers
+        include EtApi::Test::OfficeHelper
+        include EtApi::Test::I18n
+        include EtApi::Test::ClaimHelper
+
+        def self.find(repo: ActionMailer::Base.deliveries, reference:)
+          instances = repo.map { |delivery| new(delivery) }
+          instances.detect { |instance| instance.has_correct_subject? && instance.has_reference?(reference) }
+        end
+
+        def self.template_reference
+          'et1-v1-en'
+        end
+
+        def initialize(*args)
+          super(*args)
+          multipart = mail.parts.detect { |p| p.content_type =~ %r{multipart/alternative} }
+          part = multipart.parts.detect { |p| p.content_type =~ %r{text/plain} }
+          self.body = part.nil? ? '' : part.body.to_s
+          self.lines = body.lines.map { |l| l.to_s.strip }
+        end
+
+        def template_reference
+          self.class.template_reference
+        end
+
+        def has_reference?(reference)
+          submission_reference = claim_submission_reference_for(reference: reference)
+          lines.any? {|l| l.strip == "#{t('claim_email.reference', locale: template_reference)}: #{submission_reference}"}
+        end
+
+        def assert_reference(reference)
+          raise Capybara::ElementNotFound.new("Reference line incorrect for #{reference}") unless has_reference?(reference)
+        end
+
+        def has_correct_subject? # rubocop:disable Naming/PredicateName
+          mail.subject == t('claim_email.subject', locale: template_reference)
+        end
+
+        def assert_correct_to_address_for?(input_data) # rubocop:disable Naming/PredicateName
+          expect(mail.to).to match_array(input_data.confirmation_email_recipients)
+        end
+
+        def has_correct_content_for?(input_data, primary_claimant_data, claimants_file, claim_details_file, reference:) # rubocop:disable Naming/PredicateName
+          office = office_for(case_number: reference)
+          aggregate_failures 'validating content' do
+            assert_reference(reference)
+            expect(has_correct_subject?).to be true
+            expect(assert_correct_to_address_for?(input_data)).to be true
+            assert_office_information(office)
+            assert_submission_date_line
+            assert_claimant(primary_claimant_data)
+            assert_submission(primary_claimant_data, claimants_file, claim_details_file)
+            expect(attached_pdf_for(primary_claimant_data: primary_claimant_data)).to be_present
+            if claimants_file.present?
+              expect(attached_claimants_file_for(primary_claimant_data: primary_claimant_data)).to be_present
+            else
+              expect(attached_claimants_file_for(primary_claimant_data: primary_claimant_data)).not_to be_present
+            end
+            if claim_details_file.present?
+              expect(attached_info_file_for(primary_claimant_data: primary_claimant_data)).to be_present
+            else
+              expect(attached_info_file_for(primary_claimant_data: primary_claimant_data)).not_to be_present
+            end
+          end
+          true
+        end
+
+        private
+
+        def assert_submission_date
+          now = Time.zone.now
+
+          return if has_submission_date_line?(now.strftime('%d/%m/%Y'))
+          assert_submission_date_line((now - 1.minute).strftime('%d/%m/%Y'))
+        end
+
+        def assert_claimant(claimant)
+          return if lines.any? { |l| l.strip == "#{claimant.first_name} #{claimant.last_name}" }
+
+          raise Capybara::ElementNotFound.new("The claimant line was not found for #{claimant.first_name} #{claimant.last_name}")
+        end
+
+        def attached_pdf_for(primary_claimant_data:)
+          mail.parts.attachments.detect { |a| a.filename == "et1_#{scrubber primary_claimant_data.first_name.downcase}_#{scrubber primary_claimant_data.last_name.downcase}.pdf" }
+        end
+
+        def attached_claimants_file_for(primary_claimant_data:)
+          mail.parts.attachments.detect { |a| a.filename == "et1a_#{scrubber primary_claimant_data.first_name}_#{scrubber primary_claimant_data.last_name}.csv" }
+        end
+
+        def attached_info_file_for(primary_claimant_data:)
+          mail.parts.attachments.detect { |a| a.filename.end_with? '.rtf' }
+        end
+
+        def reference_line
+          lines.detect { |l| l.starts_with?('This is your reference number:') }
+        end
+
+        def assert_office_information(office)
+          return if lines.any? { |l| l.strip =~ %r{Tribunal office: \s*#{office.name}, #{office.email}, #{office.telephone}} }
+
+          raise Capybara::ElementNotFound.new("The office information line was not found for #{office.name}")
+        end
+
+        def assert_submission_date_line
+          now = Time.zone.now
+          return if lines.any? do |l|
+            l.strip =~ %r{#{t('claim_email.submission_info', locale: template_reference)}\s*#{t('claim_email.submission_date', date: l(now, format: '%d %B %Y', locale: template_reference.split('-').last), locale: template_reference)}} ||
+              l.strip =~ %r{#{t('claim_email.submission_info', locale: template_reference)}\s*#{t('claim_email.submission_date', date: l((now -1.minute), format: '%d %B %Y', locale: template_reference.split('-').last), locale: template_reference)}}
+          end
+          raise Capybara::ElementNotFound.new("The submission date line was not found")
+        end
+
+        def has_submission_date_line?
+          assert_submission_date_line
+          true
+        rescue Capybara::ElementNotFound
+          false
+        end
+
+        def assert_submission(claimant, claimants_file, claim_details_file)
+          expect(lines).to include(t('claim_email.next_steps.well_contact_you', locale: template_reference))
+          expect(lines).to include(t('claim_email.next_steps.once_sent_claim', locale: template_reference))
+          assert_submission_details(claimant, claimants_file, claim_details_file)
+        end
+
+        def assert_submission_details(primary_claimant_data, claimants_file, claim_details_file)
+          expect(body).to match(%r{#{t('claim_email.submission_details', locale: template_reference).upcase}})
+          expect(body).to match(%r{#{t('claim_email.claim_completed', locale: template_reference)}})
+          expect(body).to match(%r{#{t('claim_email.see_attached_pdf', locale: template_reference)}})
+          expect(body).to match(%r{#{t('claim_email.claim_submitted', locale: template_reference)}})
+          if claimants_file.present?
+            expect(body).to match %r{et1a_#{scrubber primary_claimant_data.first_name}_#{scrubber primary_claimant_data.last_name}.csv}
+          else
+            expect(body).not_to match %r{et1a_#{scrubber primary_claimant_data.first_name}_#{scrubber primary_claimant_data.last_name}.csv}
+          end
+
+          if claim_details_file.present?
+            expect(body).to match %r{et1_attachment_#{scrubber primary_claimant_data.first_name}_#{scrubber primary_claimant_data.last_name}.rtf}
+          else
+            expect(body).not_to match %r{et1_attachment_#{scrubber primary_claimant_data.first_name}_#{scrubber primary_claimant_data.last_name}.rtf}
+          end
+
+        end
+
+        def scrubber(text)
+          text.gsub(/\s/, '_').gsub(/\W/, '')
+        end
+
+        attr_accessor :body, :lines
+      end
+    end
+  end
+end

--- a/spec/support/email_support/emails_sent.rb
+++ b/spec/support/email_support/emails_sent.rb
@@ -21,6 +21,26 @@ module EtApi
         email
       end
 
+      def new_claim_html_email_for(reference:, template_reference:)
+        email = case template_reference
+                when /\-en\z/ then EtApi::Test::EmailObjects::NewClaimEmailEnHtml.find(reference: reference)
+                when /\-cy\z/ then EtApi::Test::EmailObjects::NewClaimEmailCyHtml.find(reference: reference)
+                else raise "Unknown template reference #{template_reference}"
+        end
+        raise "No HTML claim (ET1) email has been sent for reference #{reference} using template reference #{template_reference}" unless email.present?
+        email
+      end
+
+      def new_claim_text_email_for(reference:, template_reference:)
+        email = case template_reference
+                when /\-en\z/ then EtApi::Test::EmailObjects::NewClaimEmailEnText.find(reference: reference)
+                when /\-cy\z/ then EtApi::Test::EmailObjects::NewClaimEmailCyText.find(reference: reference)
+                else raise "Unknown template reference #{template_reference}"
+                end
+        raise "No text claim (ET1) email has been sent for reference #{reference} using template reference #{template_reference}" unless email.present?
+        email
+      end
+
       def new_feedback_email_html_for(email_address:, template_reference:)
         email = EtApi::Test::EmailObjects::NewFeedbackEmailHtml.find(email_address: email_address, template_reference: template_reference)
         raise "No HTML response for feedback email has been sent for email_address: #{email_address}" unless email.present?

--- a/spec/support/helpers/claim_helper.rb
+++ b/spec/support/helpers/claim_helper.rb
@@ -1,0 +1,13 @@
+module EtApi
+  module Test
+    module ClaimHelper
+      def claim_submission_reference_for(reference:)
+        Claim.where(reference: reference).first&.submission_reference
+      end
+
+    end
+  end
+end
+RSpec.configure do |c|
+  c.include ::EtApi::Test::OfficeHelper
+end

--- a/spec/support/messaging.rb
+++ b/spec/support/messaging.rb
@@ -34,7 +34,17 @@ module EtApi
         result.is_a?(::I18n::MissingTranslation) ? raise(result) : result
       end
 
-      alias t translate
+      alias :t :translate
+
+      # Localizes certain objects, such as dates and numbers to local formatting.
+      def localize(object, locale: nil, format: nil, **options)
+        raise I18n::Disabled.new('l') if locale == false
+
+        format ||= :default
+        backend.localize(locale, object, format, options)
+      end
+
+      alias :l :localize
 
       private
 
@@ -54,9 +64,17 @@ module EtApi
         ::EtApi::Test::Messaging.instance.t(*args)
       end
 
+      def l(*args)
+        ::EtApi::Test::Messaging.instance.l(*args)
+      end
+
       class_methods do
         def t(*args)
           ::EtApi::Test::Messaging.instance.t(*args)
+        end
+
+        def l(*args)
+          ::EtApi::Test::Messaging.instance.l(*args)
         end
 
         def factory_translate(*args)

--- a/spec/support/messaging/cy-dates.yml
+++ b/spec/support/messaging/cy-dates.yml
@@ -1,0 +1,16 @@
+cy:
+  date:
+    month_names:
+      -
+      - Ionawr
+      - Chwefror
+      - Mawrth
+      - Ebrill
+      - Mai
+      - Mehefin
+      - Gorffennaf
+      - Awst
+      - Medi
+      - Hydref
+      - Tachwedd
+      - Rhagfyr

--- a/spec/support/messaging/cy.yml
+++ b/spec/support/messaging/cy.yml
@@ -318,6 +318,11 @@ et3-v1-cy:
     office_telephone: 'Rhif ffôn: %{telephone}'
     office_name: 'Diolch am gyflwyno eich ymateb. Mae wedi cael ei anfon i’r swyddfa ym %{office_name} a byddant yn cysylltu â chi maes o law.'
     subject: 'E-bost yn cadarnhau bod eich ymateb i’r hawliad Tribiwnlys Cyflogaeth ar-lein wedi cyrraedd'
+  claim_email:
+    reference: Eich rhif hawliad
+    subject: 'Tribiwnlys Cyflogaeth: cwblhau eich hawliad'
+    submission_info: 'Hawliad wedi''i gyflwyno:'
+    submission_date: "Cyflwynwyd ar %{date}"
 et1-v1-cy:
   claim_pdf_fields:
     your_details:
@@ -742,3 +747,18 @@ et1-v1-cy:
     additional_information:
       additional_information:
         field_name: '15'
+  claim_email:
+    reference: Eich rhif hawliad
+    subject: 'Tribiwnlys Cyflogaeth: hawliad wedi''i gyflwyno'
+    submission_info: 'Hawliad wedi''i gyflwyno:'
+    submission_date: "Cyflwynwyd ar %{date}"
+    tribunal_office: 'Swyddfa tribiwnlys:'
+    thank_you: "Diolch am gyflwyno eich hawliad i dribiwnlys cyflogaeth."
+    next_steps:
+      well_contact_you: Byddwn yn cysylltu â chi unwaith y byddwn wedi anfon eich hawliad at yr atebydd i egluro beth fydd yn digwydd nesaf. Ar hyn o bryd, mae’n cymryd oddeutu 25 diwrnod.
+      once_sent_claim: Unwaith y byddwn wedi anfon eich hawliad atynt, mae gan yr atebydd 28 diwrnod i ymateb.
+    submission_details: Manylion cyflwyno
+    claim_completed: 'Hawliad wedi''i gwblhau:'
+    see_attached_pdf: Gweler y PDF sydd ynghlwm
+    claim_submitted: 'Hawliad wedi''i gyflwyno:'
+    submitted_at: "Cyflwynwyd ar %{date}"

--- a/spec/support/messaging/en.yml
+++ b/spec/support/messaging/en.yml
@@ -631,4 +631,19 @@ et1-v1-en:
     additional_information:
       additional_information:
         field_name: '15'
+  claim_email:
+    reference: Claim number
+    subject: 'Employment tribunal: claim submitted'
+    submission_info: 'Claim submitted:'
+    submission_date: Submitted %{date}
+    tribunal_office: 'Tribunal office:'
+    thank_you: Thank you for submitting your claim to an employment tribunal.
+    next_steps:
+      well_contact_you: "We'll contact you once we have sent your claim to the respondent and explain what happens next."
+      once_sent_claim: 'Once we have sent them your claim, the respondent has 28 days to reply.'
+    submission_details: Submission details
+    claim_completed: 'Claim completed:'
+    see_attached_pdf: See attached PDF
+    claim_submitted: 'Claim submitted:'
+    submitted_at: 'Submitted %{date}'
 


### PR DESCRIPTION



### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RST-1439

### Change description ###

This PR adds the API side to RST-1439 which is sending the claimant confirmation email with template selectable by the caller (ET1) to allow for multiple languages

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```

This change should be deployed before the ET1 change of the same branch.  Running this with older versions of ET1 will work fine.