### PR TITLE
RST-2578 (API) New pdf generation code was missing 2 fields

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -19,6 +19,7 @@ class Claim < ApplicationRecord
                                        through: :claim_representatives, source: :representative
   has_many :uploaded_files, through: :claim_uploaded_files
   has_many :pre_allocated_file_keys, as: :allocated_to, dependent: :destroy, inverse_of: :allocated_to
+  belongs_to :office, foreign_key: :office_code, primary_key: :code
 
   before_save :cache_claimant_count
   # @TODO RST-1080 Refactoring Tasks - 'uploaded_files' really needs renaming as these files are not only

--- a/app/services/build_claim_pdf_file_service.rb
+++ b/app/services/build_claim_pdf_file_service.rb
@@ -25,6 +25,7 @@ class BuildClaimPdfFileService # rubocop:disable Metrics/ClassLength
 
   def pdf_fields
     result = {}
+    apply_office_use_only_fields(result)
     apply_your_details_fields(result)
     apply_respondents_details_fields(result)
     apply_secondary_respondents_details_fields(result)
@@ -62,6 +63,11 @@ class BuildClaimPdfFileService # rubocop:disable Metrics/ClassLength
     apply_field result, primary_claimant.date_of_birth.year, :your_details, :dob_year
     apply_field result, primary_claimant.email_address, :your_details, :email_address
     apply_field result, primary_claimant.address_telephone_number, :your_details, :telephone_number
+  end
+
+  def apply_office_use_only_fields(result)
+    apply_field result, format_date(source.date_of_receipt), :official_use_only, :date_received
+    apply_field result, source.office&.name, :official_use_only, :tribunal_office
   end
 
   def apply_respondents_details_fields(result)

--- a/spec/support/email_support/email_objects/new_claim_email_cy_html.rb
+++ b/spec/support/email_support/email_objects/new_claim_email_cy_html.rb
@@ -1,6 +1,6 @@
 require_relative './base'
 require_relative '../../helpers/office_helper'
-require_relative './new_claim_email_en_html.rb'
+require_relative './new_claim_email_en_html'
 module EtApi
   module Test
     module EmailObjects

--- a/spec/support/helpers/office_helper.rb
+++ b/spec/support/helpers/office_helper.rb
@@ -6,6 +6,15 @@ module EtApi
         Office.where(code: office_code).first
       end
 
+      def office_from_respondent(respondent)
+        post_code = respondent.work_address_attributes.try(:post_code) || respondent.address_attributes.try(:post_code)
+        code = case post_code
+               when /\A(SW1H|WC1)/i then '22'
+               else raise "Unknown post code #{post_code} - please add to office_from_respondent method in #{__FILE__}"
+               end
+        office_for(case_number: code)
+      end
+
     end
   end
 end

--- a/spec/support/landing_folder_support/file_objects/et1_pdf_file.rb
+++ b/spec/support/landing_folder_support/file_objects/et1_pdf_file.rb
@@ -7,6 +7,7 @@ module EtApi
       # Represents the ET3 PDF file and provides assistance in validating its contents
       class Et1PdfFile < BasePdfFile
         def has_correct_contents_for?(claim:, claimants:, respondents:, representative:) # rubocop:disable Naming/PredicateName
+          Et1PdfFileSection::OfficialUseOnlySection.new(field_values, lookup_root, template: template).has_contents_for?(claim: claim, respondent: respondents.first)
           Et1PdfFileSection::YourDetailsSection.new(field_values, lookup_root, template: template).has_contents_for?(claimant: claimants.first)
           Et1PdfFileSection::RespondentsDetailsSection.new(field_values, lookup_root, template: template).has_contents_for?(respondents: respondents)
           Et1PdfFileSection::MultipleCasesSection.new(field_values, lookup_root, template: template).has_contents_for?(claim: claim)

--- a/spec/support/landing_folder_support/file_objects/et1_pdf_file/official_use_only_section.rb
+++ b/spec/support/landing_folder_support/file_objects/et1_pdf_file/official_use_only_section.rb
@@ -1,0 +1,23 @@
+require_relative './base.rb'
+require_relative '../../../helpers/office_helper'
+module EtApi
+  module Test
+    module FileObjects
+      module Et1PdfFileSection
+        class OfficialUseOnlySection < EtApi::Test::FileObjects::Et1PdfFileSection::Base
+          include EtApi::Test::OfficeHelper
+
+          def has_contents_for?(claim:, respondent:)
+            office_data = office_from_respondent(respondent)
+            expected_values = {
+              tribunal_office: office_data['name'],
+              date_received: formatted_date(Time.zone.parse(claim.date_of_receipt))
+            }
+            expect(mapped_field_values).to include expected_values
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/spec/support/messaging/cy.yml
+++ b/spec/support/messaging/cy.yml
@@ -764,6 +764,13 @@ et1-v1-cy:
     additional_information:
       additional_information:
         field_name: '15'
+    official_use_only:
+      tribunal_office:
+        field_name: 'tribunal office'
+      case_number:
+        field_name: 'case number'
+      date_received:
+        field_name: 'date received'
   claim_email:
     reference: Eich rhif hawliad
     subject: 'Tribiwnlys Cyflogaeth: hawliad wedi''i gyflwyno'

--- a/spec/support/messaging/en.yml
+++ b/spec/support/messaging/en.yml
@@ -648,6 +648,13 @@ et1-v1-en:
     additional_information:
       additional_information:
         field_name: '15'
+    official_use_only:
+      tribunal_office:
+        field_name: 'tribunal office'
+      case_number:
+        field_name: 'case number'
+      date_received:
+        field_name: 'date received'
   claim_email:
     reference: Claim number
     subject: 'Employment tribunal: claim submitted'

--- a/vendor/assets/pdf_forms/et1-v1-cy.yml
+++ b/vendor/assets/pdf_forms/et1-v1-cy.yml
@@ -447,3 +447,10 @@ final_check:
 additional_information:
   additional_information:
     field_name: '15'
+official_use_only:
+  tribunal_office:
+    field_name: 'tribunal office'
+  case_number:
+    field_name: 'case number'
+  date_received:
+    field_name: 'date received'

--- a/vendor/assets/pdf_forms/et1-v1-en.yml
+++ b/vendor/assets/pdf_forms/et1-v1-en.yml
@@ -447,3 +447,10 @@ final_check:
 additional_information:
   additional_information:
     field_name: '15'
+official_use_only:
+  tribunal_office:
+    field_name: 'tribunal office'
+  case_number:
+    field_name: 'case number'
+  date_received:
+    field_name: 'date received'


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-2578

### Change description ###

This PR adds the office name and the submission date to the PDF's generated by the API


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
