### PR TITLE
RST-1777 Reduce risk of emails being sent more than once due to sidek…

### DIFF
--- a/app/event_handlers/claim_email_handler.rb
+++ b/app/event_handlers/claim_email_handler.rb
@@ -1,12 +1,21 @@
 class ClaimEmailHandler
   def handle(claim)
-    send_email(claim) unless claim.confirmation_email_recipients.empty?
+    send_email(claim) unless has_no_recipients?(claim) || sent?(claim)
   end
 
   private
 
+  def has_no_recipients?(claim)
+    claim.confirmation_email_recipients.empty?
+  end
+
+  def sent?(claim)
+    claim.events.confirmation_email_sent.present?
+  end
+
   def send_email(claim, template_reference: claim.email_template_reference)
     office = OfficeService.lookup_by_case_number(claim.reference)
     ClaimMailer.with(claim: claim, office: office, template_reference: template_reference).confirmation_email.deliver_now
+    claim.events.confirmation_email_sent.create
   end
 end

--- a/app/event_handlers/response_email_handler.rb
+++ b/app/event_handlers/response_email_handler.rb
@@ -1,12 +1,21 @@
 class ResponseEmailHandler
   def handle(response)
-    send_email(response) if response.email_receipt.present?
+    send_email(response) unless has_no_recipient(response) || sent?(response)
   end
 
   private
 
+  def has_no_recipient(response)
+    response.email_receipt.blank?
+  end
+
+  def sent?(response)
+    response.events.confirmation_email_sent.present?
+  end
+
   def send_email(response, template_reference: response.email_template_reference)
     office = OfficeService.lookup_by_case_number(response.case_number)
     ResponseMailer.with(response: response, office: office, template_reference: template_reference).confirmation_email.deliver_now
+    response.events.confirmation_email_sent.create
   end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -20,6 +20,7 @@ class Claim < ApplicationRecord
   has_many :uploaded_files, through: :claim_uploaded_files
   has_many :pre_allocated_file_keys, as: :allocated_to, dependent: :destroy, inverse_of: :allocated_to
   belongs_to :office, foreign_key: :office_code, primary_key: :code
+  has_many :events, as: :attached_to
 
   before_save :cache_claimant_count
   # @TODO RST-1080 Refactoring Tasks - 'uploaded_files' really needs renaming as these files are not only

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,6 @@
+class Event < ApplicationRecord
+  belongs_to :attached_to, polymorphic: true
+  enum name: {
+    confirmation_email_sent: 'ConfirmationEmailSent'
+  }
+end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -4,6 +4,7 @@ class Response < ApplicationRecord
   has_many :response_uploaded_files, dependent: :destroy
   has_many :uploaded_files, through: :response_uploaded_files
   has_many :pre_allocated_file_keys, as: :allocated_to, dependent: :destroy, inverse_of: :allocated_to
+  has_many :events, as: :attached_to
 
   def office
     @office ||= Office.find_by(code: office_code)

--- a/db/migrate/20200422051542_create_events.rb
+++ b/db/migrate/20200422051542_create_events.rb
@@ -1,0 +1,11 @@
+class CreateEvents < ActiveRecord::Migration[6.0]
+  def change
+    create_table :events do |t|
+      t.references :attached_to, polymorphic: true, null: false
+      t.string :name, null: false
+      t.jsonb :data, default: {}
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2020_03_12_134523) do
+ActiveRecord::Schema.define(version: 2020_04_22_051542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -243,6 +242,16 @@ ActiveRecord::Schema.define(version: 2020_03_12_134523) do
     t.string "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.string "attached_to_type", null: false
+    t.bigint "attached_to_id", null: false
+    t.string "name", null: false
+    t.jsonb "data", default: {}
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["attached_to_type", "attached_to_id"], name: "index_events_on_attached_to_type_and_attached_to_id"
   end
 
   create_table "export_events", force: :cascade do |t|

--- a/spec/event_handlers/claim_email_handler_spec.rb
+++ b/spec/event_handlers/claim_email_handler_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe ClaimEmailHandler do
+  subject(:handler) { described_class.new }
+  let(:claim) { create(:claim, confirmation_email_recipients: ['fred@bloggs.com']) }
+  it 'sends 1 email when called twice' do
+    handler.handle(claim)
+    handler.handle(claim)
+    expect(ActionMailer::Base.deliveries.length).to be 1
+  end
+end

--- a/spec/event_handlers/response_email_handler_spec.rb
+++ b/spec/event_handlers/response_email_handler_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe ResponseEmailHandler do
+  subject(:handler) { described_class.new }
+  let(:response) { create(:response, :with_pdf_file, email_receipt: 'fred@bloggs.com') }
+
+  it 'sends 1 email when called twice' do
+    handler.handle(response)
+    handler.handle(response)
+
+    expect(ActionMailer::Base.deliveries.length).to be 1
+  end
+end


### PR DESCRIPTION



### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RST-1777


### Change description ###
This PR ensures that neither ET1 or ET3 confirmation emails can be sent more than once in the event of sidekiq retries


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
