### PR TITLE
RST-2904 Time zone is now part of the api call

### DIFF
--- a/app/commands/build_claim_command.rb
+++ b/app/commands/build_claim_command.rb
@@ -20,8 +20,10 @@ class BuildClaimCommand < BaseCommand
   attribute :pdf_template_reference, :string, default: 'et1-v2-en'
   attribute :email_template_reference, :string, default: 'et1-v1-en'
   attribute :confirmation_email_recipients, default: []
+  attribute :time_zone, :string, default: 'London'
   validates :pdf_template_reference, inclusion: { in: ['et1-v1-en', 'et1-v1-cy', 'et1-v2-en', 'et1-v2-cy'] }
   validates :email_template_reference, inclusion: { in: ['et1-v1-en', 'et1-v1-cy'] }
+  validates :time_zone, inclusion: { in: ['London'] }
 
   def initialize(*args, reference_service: ReferenceService, **kw_args)
     super(*args, **kw_args)

--- a/app/event_handlers/claim_pdf_file_handler.rb
+++ b/app/event_handlers/claim_pdf_file_handler.rb
@@ -1,7 +1,7 @@
 class ClaimPdfFileHandler
   def handle(claim)
     if claim.pdf_file.blank?
-      BuildClaimPdfFileService.new(claim, template_reference: claim.pdf_template_reference).call
+      BuildClaimPdfFileService.new(claim, template_reference: claim.pdf_template_reference, time_zone: claim.time_zone).call
       claim.save!
     end
     Rails.application.event_service.publish('ClaimPdfFileAdded', claim)

--- a/app/services/build_claim_pdf_file_service.rb
+++ b/app/services/build_claim_pdf_file_service.rb
@@ -6,8 +6,8 @@ class BuildClaimPdfFileService # rubocop:disable Metrics/ClassLength
   include PdfBuilder::ActiveStorage
   PAY_CLAIMS = ['redundancy', 'notice', 'holiday', 'arrears', 'other'].freeze
 
-  def self.call(source, template_reference: 'et1-v2-en')
-    new(source, template_reference: template_reference).call
+  def self.call(source, template_reference: 'et1-v2-en', time_zone: 'London')
+    new(source, template_reference: template_reference, time_zone: time_zone).call
   end
 
   def call
@@ -224,8 +224,8 @@ class BuildClaimPdfFileService # rubocop:disable Metrics/ClassLength
   def format_date(date, optional: false)
     return nil if date.nil? && optional
 
-    date = Date.parse(date) if date.is_a?(String)
-    date.strftime "%d/%m/%Y"
+    date = ActiveSupport::TimeZone['London'].parse(date) if date.is_a?(String)
+    date.in_time_zone(time_zone).strftime "%d/%m/%Y"
   end
 
   def owed_anything?

--- a/app/services/concerns/pdf_builder/base.rb
+++ b/app/services/concerns/pdf_builder/base.rb
@@ -4,14 +4,15 @@ module PdfBuilder
   module Base
     extend ActiveSupport::Concern
 
-    def initialize(source)
+    def initialize(source, time_zone: 'London')
       self.source = source
+      self.time_zone = time_zone
     end
 
     included do
       private
 
-      attr_accessor :source
+      attr_accessor :source, :time_zone
     end
   end
 end

--- a/app/services/concerns/pdf_builder/multi_template.rb
+++ b/app/services/concerns/pdf_builder/multi_template.rb
@@ -6,8 +6,8 @@ module PdfBuilder
   module MultiTemplate
     extend ActiveSupport::Concern
 
-    def initialize(source, template_reference:, template_dir: Rails.root.join('vendor', 'assets', 'pdf_forms'))
-      super(source)
+    def initialize(source, template_reference:, template_dir: Rails.root.join('vendor', 'assets', 'pdf_forms'), **kw_args)
+      super(source, **kw_args)
       self.template_dir = template_dir
       self.template_reference = template_reference
       self.yaml_file = File.join(template_dir, "#{template_reference}.yml")

--- a/db/migrate/20201012111151_add_time_zone_to_claims.rb
+++ b/db/migrate/20201012111151_add_time_zone_to_claims.rb
@@ -1,0 +1,5 @@
+class AddTimeZoneToClaims < ActiveRecord::Migration[6.0]
+  def change
+    add_column :claims, :time_zone, :string, default: 'London', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_100632) do
+ActiveRecord::Schema.define(version: 2020_10_12_111151) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -198,6 +198,7 @@ ActiveRecord::Schema.define(version: 2020_09_22_100632) do
     t.string "pdf_template_reference", null: false
     t.string "email_template_reference", default: "et1-v1-en", null: false
     t.string "confirmation_email_recipients", default: [], array: true
+    t.string "time_zone", default: "London", null: false
     t.index ["primary_claimant_id"], name: "index_claims_on_primary_claimant_id"
     t.index ["primary_representative_id"], name: "index_claims_on_primary_representative_id"
     t.index ["primary_respondent_id"], name: "index_claims_on_primary_respondent_id"

--- a/spec/factories/claim_factory.rb
+++ b/spec/factories/claim_factory.rb
@@ -22,6 +22,7 @@ FactoryBot.define do
     email_template_reference { "et1-v1-en" }
     claim_details { 'claim details field' }
     miscellaneous_information { 'miscellaneous information' }
+    time_zone { 'London' }
 
     after(:build) do |claim, evaluator|
       claim.primary_claimant = build(:claimant) if claim.primary_claimant.blank? && evaluator.number_of_claimants > 0

--- a/spec/factories/json/json_claim_factory.rb
+++ b/spec/factories/json/json_claim_factory.rb
@@ -114,6 +114,7 @@ FactoryBot.define do
       jurisdiction { '2' }
       office_code { '22' }
       date_of_receipt { Time.zone.now.strftime('%Y-%m-%dT%H:%M:%S%z') }
+      time_zone { 'London' }
 
       other_known_claimant_names { "" }
       discrimination_claims do

--- a/spec/services/build_claim_pdf_file_service_spec.rb
+++ b/spec/services/build_claim_pdf_file_service_spec.rb
@@ -100,5 +100,11 @@ RSpec.describe BuildClaimPdfFileService do
         end
       end
     end
+
+    context 'when submitted between 00:00 and 00:59 during BST' do
+      let(:claim) { build(:claim, :example_data, date_of_receipt: ActiveSupport::TimeZone['London'].parse('1 July 2020')) }
+
+      include_examples 'for any claim variation'
+    end
   end
 end

--- a/spec/support/landing_folder_support/file_objects/et1_pdf_file/official_use_only_section.rb
+++ b/spec/support/landing_folder_support/file_objects/et1_pdf_file/official_use_only_section.rb
@@ -11,7 +11,7 @@ module EtApi
             office_data = office_from_respondent(respondent)
             expected_values = {
               tribunal_office: office_data['name'],
-              date_received: formatted_date(Time.zone.parse(claim.date_of_receipt))
+              date_received: formatted_date(ActiveSupport::TimeZone[claim.time_zone].parse(claim.date_of_receipt))
             }
             expect(mapped_field_values).to include expected_values
           end


### PR DESCRIPTION




### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RST-2904


### Change description ###
RST-2904 Time zone is now part of the api call with a default of 'London' - it is also stored in the claim and used by pdf generation for the date



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
