### PR TITLE
RST-2951 No longer send rtf file back to user, but just filename and …

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -206,3 +206,4 @@ cy:
   et1_confirmation_email:
     rtf_not_submitted: Dim ffeil ychwanegol wedi’i llwytho i fyny
     csv_not_submitted: Dim ffeil ychwanegol wedi’i llwytho i fyny
+    rtf_submitted: Rydych wedi llwyddo i lwytho dogfen ychwanegol o’ enw %{name} gyda’ch hawliad. Maint y ffeil yw %{size}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,7 @@ en:
   et1_confirmation_email:
     rtf_not_submitted: no additional file
     csv_not_submitted: no additional file
+    rtf_submitted: You successfully uploaded an additional document named %{name} with your claim. The file size is %{size}.
 
 
 

--- a/spec/support/email_support/gov_uk_notify_email_objects/new_claim_email_cy.rb
+++ b/spec/support/email_support/gov_uk_notify_email_objects/new_claim_email_cy.rb
@@ -28,7 +28,7 @@ module EtApi
             expect(mail.dig('personalisation', 'has_claimants_file')).to eql 'no'
           end
           if claim_details_file.present?
-            expect(attached_info_file).to include 'file', 'is_csv'
+            expect(attached_info_file).to match /Rydych wedi llwyddo i lwytho dogfen ychwanegol o’ enw .* gyda’ch hawliad\. Maint y ffeil yw .*\./
             expect(mail.dig('personalisation', 'has_additional_info')).to eql 'yes'
           else
             expect(attached_info_file).to eq 'Dim ffeil ychwanegol wedi’i llwytho i fyny'

--- a/spec/support/email_support/gov_uk_notify_email_objects/new_claim_email_en.rb
+++ b/spec/support/email_support/gov_uk_notify_email_objects/new_claim_email_en.rb
@@ -55,7 +55,7 @@ module EtApi
               expect(mail.dig('personalisation', 'has_claimants_file')).to eql 'no'
             end
             if claim_details_file.present?
-              expect(attached_info_file).to include 'file', 'is_csv'
+              expect(attached_info_file).to match /You successfully uploaded an additional document named .* with your claim\. The file size is .*\./
               expect(mail.dig('personalisation', 'has_additional_info')).to eql 'yes'
             else
               expect(attached_info_file).to eq 'no additional file'


### PR DESCRIPTION


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RST-2951


### Change description ###
RST-2951 No longer send rtf file back to user, but just filename and file size


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
