### PR TITLE
RST-2951 No longer send csv file back to user, but just filename and …

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -207,3 +207,4 @@ cy:
     rtf_not_submitted: Dim ffeil ychwanegol wedi’i llwytho i fyny
     csv_not_submitted: Dim ffeil ychwanegol wedi’i llwytho i fyny
     rtf_submitted: Rydych wedi llwyddo i lwytho dogfen ychwanegol o’ enw %{name} gyda’ch hawliad. Maint y ffeil yw %{size}.
+    csv_submitted: Rydych wedi llwyddo i lwytho hawliad grŵp ar ffurf ffeil csv o'r enw %{name} gyda'ch hawliad. Maint y ffeil yw %{size}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,7 @@ en:
     rtf_not_submitted: no additional file
     csv_not_submitted: no additional file
     rtf_submitted: You successfully uploaded an additional document named %{name} with your claim. The file size is %{size}.
+    csv_submitted: You successfully uploaded a group claim csv file named %{name} with your claim. The file size is %{size}.
 
 
 

--- a/spec/support/email_support/gov_uk_notify_email_objects/new_claim_email_cy.rb
+++ b/spec/support/email_support/gov_uk_notify_email_objects/new_claim_email_cy.rb
@@ -21,7 +21,7 @@ module EtApi
           assert_claimant(primary_claimant_data)
           expect(attached_pdf_file).to include 'file', 'is_csv'
           if claimants_file.present?
-            expect(attached_claimants_file).to include 'file', 'is_csv'
+            expect(attached_claimants_file).to match /Rydych wedi llwyddo i lwytho hawliad grŵp ar ffurf ffeil csv o'r enw .* gyda'ch hawliad\. Maint y ffeil yw .*./
             expect(mail.dig('personalisation', 'has_claimants_file')).to eql 'yes'
           else
             expect(attached_claimants_file).to eq 'Dim ffeil ychwanegol wedi’i llwytho i fyny'

--- a/spec/support/email_support/gov_uk_notify_email_objects/new_claim_email_en.rb
+++ b/spec/support/email_support/gov_uk_notify_email_objects/new_claim_email_en.rb
@@ -48,7 +48,7 @@ module EtApi
             assert_claimant(primary_claimant_data)
             expect(attached_pdf_file).to include 'file', 'is_csv'
             if claimants_file.present?
-              expect(attached_claimants_file).to include 'file', 'is_csv'
+              expect(attached_claimants_file).to match /You successfully uploaded a group claim csv file named .* with your claim\. The file size is .*\./
               expect(mail.dig('personalisation', 'has_claimants_file')).to eql 'yes'
             else
               expect(attached_claimants_file).to eq 'no additional file'


### PR DESCRIPTION
RST-2951 No longer send csv file back to user, but just filename and file size



### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
