### PR TITLE
Rst 2905 ET3 Repair functionality

### DIFF
--- a/app/commands/rebuild_representative_command.rb
+++ b/app/commands/rebuild_representative_command.rb
@@ -1,0 +1,10 @@
+class RebuildRepresentativeCommand < BuildRepresentativeCommand
+  def apply(root_object, **_args)
+    new_attributes = attributes.dup
+    if root_object.representative.address_id && new_attributes.key?('address_attributes')
+      new_attributes['address_attributes'].merge!('id' => root_object.representative.address_id)
+    end
+    root_object.representative.attributes = new_attributes
+    root_object.representative.save(touch: false)
+  end
+end

--- a/app/commands/rebuild_respondent_command.rb
+++ b/app/commands/rebuild_respondent_command.rb
@@ -1,0 +1,13 @@
+class RebuildRespondentCommand < BuildRespondentCommand
+  def apply(root_object, **_args)
+    new_attributes = attributes.dup
+    if root_object.respondent.address_id && new_attributes.key?('address_attributes')
+      new_attributes['address_attributes'].merge!('id' => root_object.respondent.address_id)
+    end
+    if root_object.respondent.work_address_id && new_attributes.key?('work_address_attributes')
+      new_attributes['work_address_attributes'].merge!('id' => root_object.respondent.work_address_id)
+    end
+    root_object.respondent.attributes = attributes
+    root_object.respondent.save(touch: false)
+  end
+end

--- a/app/commands/rebuild_respondent_command.rb
+++ b/app/commands/rebuild_respondent_command.rb
@@ -7,7 +7,7 @@ class RebuildRespondentCommand < BuildRespondentCommand
     if root_object.respondent.work_address_id && new_attributes.key?('work_address_attributes')
       new_attributes['work_address_attributes'].merge!('id' => root_object.respondent.work_address_id)
     end
-    root_object.respondent.attributes = attributes
+    root_object.respondent.attributes = new_attributes
     root_object.respondent.save(touch: false)
   end
 end

--- a/app/commands/rebuild_response_additional_information_file_command.rb
+++ b/app/commands/rebuild_response_additional_information_file_command.rb
@@ -1,0 +1,32 @@
+class RebuildResponseAdditionalInformationFileCommand < BuildResponseAdditionalInformationFileCommand
+  def apply(root_object, **_args)
+    delete_rtf_file_if_faulty(root_object)
+    return if rtf_file_exists?(root_object)
+
+    super
+  end
+
+  private
+
+  def rtf_file_exists?(root_object)
+    root_object.uploaded_files.et3_input_rtf.first.present?
+  end
+
+  def delete_rtf_file_if_faulty(root_object)
+    uploaded_file = root_object.uploaded_files.et3_input_rtf.first
+    return if uploaded_file.nil?
+
+    service = uploaded_file.file.service
+    service.blobs.get_blob_properties(service.container, uploaded_file.file.blob.key)
+    true
+  rescue ::Azure::Core::Http::HTTPError
+    delete_rtf_file(root_object)
+  end
+
+  def delete_rtf_file(root_object)
+    uploaded_file = root_object.uploaded_files.et3_input_rtf.first
+    string_io = StringIO.new("This file is uploaded only to allow the deletion of the blob to work without error")
+    uploaded_file.file.blob.upload(string_io, identify: false)
+    root_object.uploaded_files.et3_input_rtf.destroy_all
+  end
+end

--- a/app/commands/rebuild_response_command.rb
+++ b/app/commands/rebuild_response_command.rb
@@ -1,0 +1,20 @@
+class RebuildResponseCommand < BuildResponseCommand
+  def apply(root_object, meta: {})
+    apply_root_attributes(attributes, to: root_object)
+    allocate_pdf_file(root_object)
+  end
+
+  private
+
+  def apply_root_attributes(input_data, to:)
+    to.attributes = input_data
+    office_code = to.case_number[0..1]
+    to.office ||= Office.find_by(code: office_code)
+    to.reference ||= "#{office_code}#{reference_service.next_number}00"
+    to.date_of_receipt ||= Time.zone.now
+  end
+
+  def allocate_pdf_file(root_object)
+    super unless root_object.pdf_file.present?
+  end
+end

--- a/app/commands/recreate_response_command.rb
+++ b/app/commands/recreate_response_command.rb
@@ -1,0 +1,18 @@
+class RecreateResponseCommand < SerialSequenceCommand
+  def initialize(uuid:, data:, **args)
+    extra_commands = []
+    build_response = data.detect { |c| c[:command] == 'RebuildResponse' }
+    key = build_response[:data].delete(:additional_information_key)
+    unless key.nil?
+      extra_commands << { uuid: SecureRandom.uuid, command: 'RebuildResponseAdditionalInformationFile',
+                          data: { filename: 'additional_information.rtf', data_from_key: key } }
+    end
+    super uuid: uuid, data: data + extra_commands, **args
+  end
+
+  def apply(root_object, meta: {})
+    super
+    root_object.save!
+    EventService.publish('ResponseRecreated', root_object)
+  end
+end

--- a/app/commands/repair_response_command.rb
+++ b/app/commands/repair_response_command.rb
@@ -1,0 +1,28 @@
+class RepairResponseCommand < BaseCommand
+  attribute :response_id
+
+  validate :validate_response_presence
+
+# @param [Hash] root_object Not used - nothing to update from using this command
+# @param [Hash] meta - Not used in this command
+  def apply(root_object, meta: {})
+    event_service.publish('ResponseRepairRequested', root_object)
+  end
+
+  private
+
+  def response
+    return @response if defined?(@response)
+
+    @response = Response.find_by(id: response_id)
+  end
+
+  def validate_response_presence
+    return if response.present?
+
+    errors.add :response_id, :response_not_found,
+               response_id: response_id,
+               uuid: uuid,
+               command: command_name
+  end
+end

--- a/app/controllers/api/v2/respondents/repair_responses_controller.rb
+++ b/app/controllers/api/v2/respondents/repair_responses_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Api
+  module V2
+    module Respondents
+      class RepairResponsesController < ::Api::V2::BaseController
+        include CacheCommandResults
+
+        cache_command_results only: :create
+
+        def create
+          root_object = ::Response.find_by(id: repair_response_params.dig(:data, :response_id))
+          command = CommandService.command_for(**repair_response_params.merge(command: 'RepairResponse').to_h.symbolize_keys)
+          if command.valid?
+            result = CommandService.dispatch command: command, root_object: root_object
+            render locals: { result: result }, status: (result.valid? ? :accepted : :unprocessable_entity)
+            self.cached_root_object = root_object
+          else
+            render locals: { command: command }, status: :bad_request, template: 'api/v2/shared/command_errors'
+          end
+        end
+
+        private
+
+        def repair_response_params
+          params.permit(:uuid, :command, data: {}).to_h
+        end
+      end
+    end
+  end
+end

--- a/app/event_handlers/repair_uploaded_files_handler.rb
+++ b/app/event_handlers/repair_uploaded_files_handler.rb
@@ -1,0 +1,37 @@
+class RepairUploadedFilesHandler
+  def handle(root_object)
+    root_object.uploaded_files.includes(:file_attachment).each do |uploaded_file|
+      next if file_is_ok?(uploaded_file) || (uploaded_file.import_from_key.nil? && uploaded_file.import_file_url.nil?)
+
+      import_from_key(uploaded_file, root_object)
+      import_from_url(uploaded_file, root_object)
+    end
+
+    root_object.save if root_object.changed?
+  end
+
+  private
+
+  def import_from_url(uploaded_file, root_object)
+    UploadedFileImportService.import_file_url(uploaded_file.import_file_url, into: uploaded_file)
+  end
+
+  def import_from_key(uploaded_file, root_object)
+    UploadedFileImportService.import_from_key(uploaded_file.import_from_key, into: uploaded_file)
+  rescue Azure::Core::Http::HTTPError => ex
+    if ex.status_code == 404
+      uploaded_file.destroy
+      root_object.events.response_repair_file_failed.create data: {
+        id: uploaded_file.id,
+        filename: uploaded_file.filename,
+        reason: 'Externally uploaded file no longer present to import'
+      }
+    else
+      raise ex
+    end
+  end
+
+  def file_is_ok?(uploaded_file)
+    uploaded_file.present? && uploaded_file.file.attachment.present?
+  end
+end

--- a/app/event_handlers/reprepare_response_handler.rb
+++ b/app/event_handlers/reprepare_response_handler.rb
@@ -1,0 +1,40 @@
+class ReprepareResponseHandler
+  def handle(response)
+    ActiveRecord::Base.transaction do
+      ImportUploadedFilesHandler.new.handle(response)
+      delete_faulty_uploaded_files(response)
+      ResponsePdfFileHandler.new.handle(response) unless pdf_file_exists?(response)
+      response.save if response.changed?
+    end
+    EventService.publish('ResponsePrepared', response)
+  end
+
+  private
+
+  def pdf_file_exists?(response)
+    response.uploaded_files.et3_pdf.first.present?
+  end
+
+  def uploaded_file_faulty?(uploaded_file)
+    return true unless uploaded_file.present? && uploaded_file.file.attachment.present?
+    service = uploaded_file.file.service
+    service.blobs.get_blob_properties(service.container, uploaded_file.file.blob.key)
+    false
+  rescue ::Azure::Core::Http::HTTPError
+    true
+  end
+
+  def delete_faulty_uploaded_files(response)
+    response.uploaded_files.each do |uploaded_file|
+      next unless uploaded_file_faulty?(uploaded_file)
+      delete_uploaded_file uploaded_file
+    end
+  end
+
+
+  def delete_uploaded_file(uploaded_file)
+    io = StringIO.new("This file is uploaded only to allow the deletion of the blob to work without error")
+    uploaded_file.file.blob.upload(io, identify: false)
+    uploaded_file.destroy
+  end
+end

--- a/app/event_handlers/response_repair_requested_handler.rb
+++ b/app/event_handlers/response_repair_requested_handler.rb
@@ -1,5 +1,6 @@
 class ResponseRepairRequestedHandler
   def handle(response)
+    response.events.response_repair_requested.create
     original_command = response.commands.first
     request_json = ::JSON.parse(original_command.request_body).deep_symbolize_keys
     return unless request_json[:data].is_a?(Array)

--- a/app/event_handlers/response_repair_requested_handler.rb
+++ b/app/event_handlers/response_repair_requested_handler.rb
@@ -1,0 +1,21 @@
+class ResponseRepairRequestedHandler
+  def handle(response)
+    original_command = response.commands.first
+    request_json = ::JSON.parse(original_command.request_body).deep_symbolize_keys
+    return unless request_json[:data].is_a?(Array)
+
+    converted_json = convert_to_repair_commands(request_json)
+
+    CommandService.dispatch root_object: response, **converted_json
+    Rails.application.event_service.publish('ResponseRepaired', response)
+  end
+
+  def convert_to_repair_commands(json)
+    converted_json = json.dup
+    converted_json[:command] = 'RecreateResponse'
+    converted_json[:data].each do |command|
+      command[:command] = command[:command].gsub(/Build/, 'Rebuild')
+    end
+    converted_json
+  end
+end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -21,6 +21,7 @@ class Claim < ApplicationRecord
   has_many :pre_allocated_file_keys, as: :allocated_to, dependent: :destroy, inverse_of: :allocated_to
   belongs_to :office, foreign_key: :office_code, primary_key: :code
   has_many :events, as: :attached_to
+  has_many :commands, as: :root_object
 
   before_save :cache_claimant_count
   # @TODO RST-1080 Refactoring Tasks - 'uploaded_files' really needs renaming as these files are not only

--- a/app/models/command.rb
+++ b/app/models/command.rb
@@ -1,3 +1,5 @@
 class Command < ApplicationRecord
   belongs_to :root_object, polymorphic: true, optional: true, autosave: false, inverse_of: false
+
+  default_scope { order(created_at: :asc) }
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,6 +6,11 @@ class Event < ApplicationRecord
     claim_prepared: 'ClaimPrepared',
     claim_queued_for_export: 'ClaimQueuedForExport',
     claim_exported_to_atos_queue: 'ClaimExportedToAtosQueue',
-    response_exported_to_atos_queue: 'ResponseExportedToAtosQueue'
+    response_exported_to_atos_queue: 'ResponseExportedToAtosQueue',
+    response_repair_requested: 'ResponseRepairRequested',
+    response_re_prepared: 'ResponseRePrepared',
+    response_recreated_pdf: 'ResponseReCreatedPdf',
+    response_deleted_broken_file: 'ResponseDeletedBrokenFile',
+    response_repair_file_failed: 'ResponseRepairFileFailed'
   }
 end

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -6,6 +6,7 @@ class Response < ApplicationRecord
   has_many :pre_allocated_file_keys, as: :allocated_to, dependent: :destroy, inverse_of: :allocated_to
   has_many :events, as: :attached_to
   belongs_to :office
+  has_many :commands, as: :root_object
 
   def office_code
     reference[0..1]

--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -6,9 +6,14 @@ class UploadedFile < ApplicationRecord
   include StoredFileDownload
   include StoredFileBase64Import
 
+  has_many :response_uploaded_files, dependent: :destroy
+
   scope :not_hidden, -> { where('filename NOT LIKE ? AND filename NOT LIKE ? AND filename NOT LIKE ?', 'acas_%', 'et1_%.txt', 'et1a_%.txt') }
   scope :not_pdf, -> { where('filename NOT LIKE ?', 'et1_%.pdf') }
   scope :et1_pdf, -> { where('filename LIKE ?', 'et1_%.pdf') }
   scope :et1_rtf, -> { where('filename LIKE ?', 'et1_%.rtf') }
   scope :et1_csv, -> { where('filename LIKE ?', 'et1a_%.csv') }
+  scope :et3_pdf, -> { where('filename LIKE ?', 'et3_atos_export.pdf') }
+  scope :et3_input_rtf, -> { where('filename LIKE ?', 'additional_information.rtf') }
+  scope :et3_output_rtf, -> { where('filename LIKE ?', 'et3_atos_export.rtf') }
 end

--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -16,4 +16,8 @@ class UploadedFile < ApplicationRecord
   scope :et3_pdf, -> { where('filename LIKE ?', 'et3_atos_export.pdf') }
   scope :et3_input_rtf, -> { where('filename LIKE ?', 'additional_information.rtf') }
   scope :et3_output_rtf, -> { where('filename LIKE ?', 'et3_atos_export.rtf') }
+
+  def to_be_imported?
+    import_from_key.present? || import_file_url.present?
+  end
 end

--- a/app/views/api/v2/respondents/repair_responses/create.json.jbuilder
+++ b/app/views/api/v2/respondents/repair_responses/create.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.status result.valid? ? 'accepted' : 'invalid'
+json.meta result.meta
+json.uuid result.uuid

--- a/config/initializers/event_handlers.rb
+++ b/config/initializers/event_handlers.rb
@@ -1,5 +1,7 @@
 Rails.application.config.after_initialize do |app|
   app.event_service.subscribe('ResponseCreated', PrepareResponseHandler, async: true, in_process: false)
+  app.event_service.subscribe('ResponseRecreated', ReprepareResponseHandler, async: true, in_process: false)
+  app.event_service.subscribe('ResponseRepairRequested', ResponseRepairRequestedHandler, async: true, in_process: false)
   app.event_service.subscribe('ResponsePreparedForAtosExport', ResponseExportHandler, async: true, in_process: false)
   app.event_service.subscribe('ResponseExportedToAtosQueue', ResponseExportedToAtosQueueHandler, async: false, in_process: true)
   app.event_service.subscribe('ResponsePrepared', ResponseEmailHandler, async: true, in_process: false)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       end
       namespace :respondents do
         post "build_response" => 'build_responses#create'
+        post "repair_response" => 'repair_responses#create'
       end
       namespace :diversity do
         post "build_diversity_response" => 'build_diversity_responses#create'

--- a/db/migrate/20201013060132_repopulate_missing_et3_rtf_files_from1409.rb
+++ b/db/migrate/20201013060132_repopulate_missing_et3_rtf_files_from1409.rb
@@ -1,0 +1,37 @@
+class RepopulateMissingEt3RtfFilesFrom1409 < ActiveRecord::Migration[6.0]
+  class Command < ActiveRecord::Base
+    self.table_name = :commands
+  end
+
+  class Response < ActiveRecord::Base
+    self.table_name = :responses
+    has_many :response_uploaded_files, foreign_key: :response_id
+    has_many :uploaded_files, through: :response_uploaded_files
+  end
+
+  def up
+    Command.where('request_body LIKE ? AND created_at > ? AND created_at < ?', '%BuildResponse%', DateTime.parse('14/9/2020 00:00:00'), DateTime.parse('14/9/2020 23:59:59')).all.each do |command|
+      build_response_command = JSON.parse(command.request_body).with_indifferent_access['data'].detect {|c| c['command'] == 'BuildResponse'}
+      reference = JSON.parse(command.response_body).with_indifferent_access.dig('meta', 'BuildResponse', 'reference')
+      response = Response.where(reference: reference).first
+      next if build_response_command.dig('data', 'additional_information_key').nil? || response.nil? || response.uploaded_files.where('filename LIKE ?', '%.rtf').count > 0
+
+      announce "Adding new RTF file for response id #{response.id} reference #{response.reference}"
+      input_data = build_response_command['data']
+      key = input_data.delete('additional_information_key')
+      uploaded_file = response.uploaded_files.create(input_data.merge(import_file_url: nil, import_from_key: key))
+      begin
+        UploadedFileImportService.import_from_key(key, into: uploaded_file)
+      rescue ActiveStorage::FileNotFoundError
+        announce "Attempt to fetch blob with key #{key} failed - file not found"
+        uploaded_file.destroy
+      end
+      response.save(touch:false)
+      announce "Added new RTF file for claim id #{claim.id} reference #{claim.reference}"
+    end
+  end
+
+  def down
+    # Do nothing
+  end
+end

--- a/db/migrate/20201030081306_migrate_commands_with_no_root_object.rb
+++ b/db/migrate/20201030081306_migrate_commands_with_no_root_object.rb
@@ -1,0 +1,47 @@
+class MigrateCommandsWithNoRootObject < ActiveRecord::Migration[6.0]
+  class Command < ActiveRecord::Base
+    self.table_name = :commands
+  end
+
+  class Response < ActiveRecord::Base
+    self.table_name = :responses
+  end
+
+  class Claim < ActiveRecord::Base
+    self.table_name = :claims
+  end
+
+  def up
+    Command.transaction do
+      Command.where(root_object_id: nil).find_each do |command|
+        begin
+          request_json = JSON.parse(command.request_body)
+          response_json = JSON.parse(command.response_body)
+
+          if request_json['command'] == 'SerialSequence' && request_json['data'].detect {|c| c['command'] == 'BuildResponse'}
+            next unless response_json['status'] == 'accepted'
+
+            response = Response.find_by(reference: response_json.dig('meta', 'BuildResponse', 'reference'))
+            next if response.nil?
+
+            command.update root_object_id: response.id, root_object_type: 'Response'
+          elsif request_json['command'] == 'SerialSequence' && request_json['data'].detect {|c| c['command'] == 'BuildClaim'}
+            next unless response_json['status'] == 'accepted'
+
+            claim = Claim.find_by(reference: response_json.dig('meta', 'BuildClaim', 'reference'))
+            next if claim.nil?
+
+            command.update root_object_id: claim.id, root_object_type: 'Claim'
+          end
+
+        rescue ::JSON::ParserError
+          next
+        end
+      end
+    end
+  end
+
+  def down
+    # Do nothing
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_23_053043) do
+ActiveRecord::Schema.define(version: 2020_10_30_081306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/factories/command_factory.rb
+++ b/spec/factories/command_factory.rb
@@ -1,0 +1,98 @@
+FactoryBot.define do
+  factory :command do
+    transient do
+      request_body_factory { nil }
+    end
+    request_headers do
+      {
+        "PATH_INFO"=>"/api/v2/respondents/build_response", "REMOTE_ADDR"=>"192.169.1.174", "SCRIPT_NAME"=>"", "SERVER_NAME"=>"et-api.employmenttribunal", "SERVER_PORT"=>"8080", "CONTENT_TYPE"=>"application/json", "QUERY_STRING"=>"", "CONTENT_LENGTH"=>"2326", "REQUEST_METHOD"=>"POST", "SERVER_PROTOCOL"=>"HTTP/1.1"
+      }
+    end
+    response_headers do
+      {
+        "Content-Type"=>"application/json; charset=utf-8", "Referrer-Policy"=>"strict-origin-when-cross-origin", "X-Frame-Options"=>"SAMEORIGIN", "X-XSS-Protection"=>"1; mode=block", "X-Download-Options"=>"noopen", "X-Content-Type-Options"=>"nosniff", "X-Permitted-Cross-Domain-Policies"=>"none"
+      }
+    end
+    response_status { 202 }
+  end
+  factory :build_response_command, parent: :command do
+    transient do
+      reference { '222000000300' }
+      respondent_name { 'Fred Bloggs' }
+      db_source { nil }
+      additional_information_key { nil }
+    end
+
+    trait :default do
+      request_body_factory { build(:json_build_response_commands) }
+      request_body { request_body_factory.to_json }
+      response_body do
+        {
+          status: :accepted,
+          meta: {
+            BuildResponse: {
+              submitted_at: 10.days.ago,
+              reference: reference,
+              office_address: 'Doesnt matter',
+              office_phone_number: '01234 567890',
+              office_email: 'test@example.com',
+              pdf_url: 'https://fairly.irrelevant.as.it.will.be.expired'
+            },
+            BuildRespondent: {},
+            BuildRepresentative: {},
+            BuildResponseAdditionalInformationFile: {}
+          },
+          uuid: request_body_factory.uuid
+        }.to_json
+      end
+    end
+
+    trait :from_db do
+      request_body_factory do
+        build :json_build_response_commands,
+              response_attrs: db_source.attributes
+                              .to_h
+                              .with_indifferent_access.slice(:reference, :case_number, :claimants_name, :disagree_conciliation_reason,
+                                                             :agree_with_employment_dates, :agree_with_claimants_description_of_job_or_title,
+                                                             :continued_employment, :disagree_claimants_job_or_title, :disagree_employment,
+                                                             :employment_end, :employment_start, :agree_with_earnings_details,
+                                                             :agree_with_claimants_hours, :agree_with_claimant_notice,
+                                                             :agree_with_claimant_pension_benefits, :queried_hours,
+                                                             :queried_pay_before_tax, :queried_pay_before_tax_period,
+                                                             :queried_take_home_pay, :queried_take_home_pay_period,
+                                                             :disagree_claimant_notice_reason,
+                                                             :disagree_claimant_pension_benefits_reason,
+                                                             :defend_claim, :defend_claim_facts,
+                                                             :claim_information, :make_employer_contract_claim)
+                              .merge(additional_information_key: additional_information_key),
+              respondent_attrs: db_source
+                                .respondent.attributes
+                                .to_h
+                                .with_indifferent_access
+                                .slice(:name, :contact, :address_telephone_number, :alt_phone_number, :dx_number, :fax_number, :organisation_more_than_one_site, :disability, :disability_information)
+                                .merge(address_attributes: db_source.respondent.address.attributes.to_h.with_indifferent_access.slice(:building, :street, :locality, :county, :post_code))
+
+      end
+      request_body { request_body_factory.to_json }
+      response_body do
+        {
+          status: :accepted,
+          meta: {
+            BuildResponse: {
+              submitted_at: 10.days.ago,
+              reference: reference,
+              office_address: 'Doesnt matter',
+              office_phone_number: '01234 567890',
+              office_email: 'test@example.com',
+              pdf_url: 'https://fairly.irrelevant.as.it.will.be.expired'
+            },
+            BuildRespondent: {},
+            BuildRepresentative: {},
+            BuildResponseAdditionalInformationFile: {}
+          },
+          uuid: request_body_factory.uuid
+        }.to_json
+      end
+    end
+  end
+end

--- a/spec/factories/command_factory.rb
+++ b/spec/factories/command_factory.rb
@@ -70,7 +70,16 @@ FactoryBot.define do
                                 .to_h
                                 .with_indifferent_access
                                 .slice(:name, :contact, :address_telephone_number, :alt_phone_number, :dx_number, :fax_number, :organisation_more_than_one_site, :disability, :disability_information)
-                                .merge(address_attributes: db_source.respondent.address.attributes.to_h.with_indifferent_access.slice(:building, :street, :locality, :county, :post_code))
+                                .merge(address_attributes: db_source.respondent.address.attributes.to_h.with_indifferent_access.slice(:building, :street, :locality, :county, :post_code)),
+              representative_attrs: db_source
+                                    .representative&.attributes
+                                      &.to_h
+                                      &.with_indifferent_access
+                                      &.slice(:name, :organisation_name, :address_telephone_number, :mobile_number, :email_address, :representative_type, :dx_number, :reference, :contact_preference, :fax_number)
+                                      &.merge(address_attributes: db_source.representative.address.attributes.to_h.with_indifferent_access.slice(:building, :street, :locality, :county, :post_code)),
+              representative_traits: db_source.representative.present? ? [] : nil
+
+
 
       end
       request_body { request_body_factory.to_json }

--- a/spec/factories/json/json_response_factory.rb
+++ b/spec/factories/json/json_response_factory.rb
@@ -7,8 +7,11 @@ FactoryBot.define do
       pdf_template { 'et3-v2-en' }
       email_template { 'et3-v1-en' }
       response_traits { [:full] }
+      response_attrs { {} }
       respondent_traits { [:full, :et3] }
+      respondent_attrs { {} }
       representative_traits { nil }
+      representative_attrs { {} }
     end
     uuid { SecureRandom.uuid }
     command { 'SerialSequence' }
@@ -62,16 +65,25 @@ FactoryBot.define do
       evaluator.instance_eval do
         if response_traits
           doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildResponse',
-                                           data: build(:json_response_data, *response_traits, pdf_template_reference: pdf_template, email_template_reference: email_template))
+                                           data: build(:json_response_data, *response_traits, pdf_template_reference: pdf_template, email_template_reference: email_template, **response_attrs.symbolize_keys))
         end
         if respondent_traits
-          doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildRespondent', data: build(:json_respondent_data, *respondent_traits))
+          doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildRespondent', data: build(:json_respondent_data, *respondent_traits, **respondent_attrs.symbolize_keys))
         end
         if representative_traits
-          doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildRepresentative', data: build(:json_representative_data, *representative_traits))
+          doc.data << build(:json_command, uuid: SecureRandom.uuid, command: 'BuildRepresentative', data: build(:json_representative_data, *representative_traits, **representative_attrs.symbolize_keys))
         end
       end
     end
+  end
+
+  factory :json_repair_response_command, class: ::EtApi::Test::Json::Document do
+    transient do
+      response_id { nil }
+    end
+    uuid { SecureRandom.uuid }
+    command { 'RepairResponse' }
+    data { { response_id: response_id } }
   end
 
   factory :json_response_data, class: ::EtApi::Test::Json::Node do

--- a/spec/factories/response_factory.rb
+++ b/spec/factories/response_factory.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :response do
     transient do
       ready_for_export_to { [] }
+      additional_information_key { nil }
     end
     date_of_receipt { Time.zone.now }
     case_number { '2212345/2016' }
@@ -82,6 +83,16 @@ FactoryBot.define do
     trait :example_data do
       reference { "222000000300" }
       association :respondent, :example_data
+    end
+
+    trait :broken_with_files_missing do
+      example_data
+    end
+
+    trait :with_command do
+      after(:build) do |instance, evaluator|
+        instance.commands = [build(:build_response_command, :from_db, db_source: instance, additional_information_key: evaluator.additional_information_key)]
+      end
     end
   end
 end

--- a/spec/factories/uploaded_file_factory.rb
+++ b/spec/factories/uploaded_file_factory.rb
@@ -66,7 +66,7 @@ FactoryBot.define do
         new_file        = Tempfile.new(crlf_newline: true)
         original_filename = Rails.root.join('spec', 'fixtures', 'et3.txt')
         File.open(original_filename, 'r') do |f|
-          f.lines.each do |line|
+          f.each_line do |line|
             new_file.puts line
           end
         end

--- a/spec/fixtures/et3.txt
+++ b/spec/fixtures/et3.txt
@@ -11,43 +11,43 @@ Online Submission Reference: 241000085500
 
 FormVersion: 2
 
-## Intro:
+## Intro: 
 
-**In the claim of:
+**In the claim of: 
 **Case number: 1234567/2014
 **Tribunal office: manchesteret@hmcts.gsi.gov.uk
 
 ## Section 1: Claimant's name
 
-~1.1 Claimant's name:
+~1.1 Claimant's name: 
 
 ## Section 2: Your organisation's details
 
 ~2.1 Name of your organisation: ewer
-Contact name:
+Contact name: 
 ~2.2 Address
 Address 1: wer
 Address 2: wre
 Address 3: er
-Address 4:
+Address 4: 
 Postcode: b54uu
-~2.3 Phone number:
+~2.3 Phone number: 
 Mobile number:
-~2.4 How would you prefer us to communicate with you?:
-E-mail address:
+~2.4 How would you prefer us to communicate with you?: 
+E-mail address: 
 
 ## Section 7: Your representative
 
-~7.1 Representative's name:
-~7.2 Name of the representative's organisation:
-Representative's Address 1:
-Representative's Address 2:
-Representative's Address 3:
-Representative's Address 4:
-Representative's Postcode:
-~7.4 Representative's Phone number:
-~7.5 Representative's Reference:
-~7.6 How would they prefer us to communicate with them?:
-Representative's E-mail address:
+~7.1 Representative's name: 
+~7.2 Name of the representative's organisation: 
+Representative's Address 1: 
+Representative's Address 2: 
+Representative's Address 3: 
+Representative's Address 4: 
+Representative's Postcode: 
+~7.4 Representative's Phone number: 
+~7.5 Representative's Reference: 
+~7.6 How would they prefer us to communicate with them?: 
+Representative's E-mail address: 
 
 **Version: Jadu 1.0

--- a/spec/requests/v2/repair_response_spec.rb
+++ b/spec/requests/v2/repair_response_spec.rb
@@ -1,0 +1,420 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe 'Repair Response Request', type: :request do
+  describe 'POST /api/v2/respondents/repair_response' do
+    let(:default_headers) do
+      {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      }
+    end
+    let(:errors) { [] }
+    let(:json_response) { JSON.parse(response.body).with_indifferent_access }
+
+    shared_context 'with staging folder visibility' do
+      def force_export_now
+        EtAtosExport::ClaimsExportJob.perform_now
+      end
+
+      def formatted_name_for_filename(text)
+        text.parameterize(separator: '_', preserve_case: true)
+      end
+
+      before do
+        stub_request(:any, /mocked_atos_server\.com/).to_rack(EtAtosFileTransfer::Engine)
+      end
+
+      let(:staging_folder) do
+        EtApi::Test::StagingFolder.new url: 'http://mocked_atos_server.com',
+                                       username: 'atos',
+                                       password: 'password'
+      end
+
+      let(:secondary_staging_folder) do
+        EtApi::Test::StagingFolder.new url: 'http://mocked_atos_server.com',
+                                       username: 'atos2',
+                                       password: 'password'
+      end
+
+      let(:emails_sent) do
+        EtApi::Test::EmailsSent.new
+      end
+    end
+
+    shared_context 'with setup for any response' do
+      let(:input_response_factory) { input_factory.data.detect { |d| d.command == 'BuildResponse' }.data }
+      let(:input_respondent_factory) { input_factory.data.detect { |d| d.command == 'BuildRespondent' }.data }
+      let(:input_representative_factory) { input_factory.data.detect { |d| d.command == 'BuildRepresentative' }.try(:data) }
+      let(:output_files_generated) { [] }
+      let(:input_json) { build(:json_repair_response_command, response_id: response_to_repair.id).as_json }
+      let(:input_response_attributes) { response_to_repair.attributes.to_h.with_indifferent_access }
+      let(:input_respondent_attributes) do
+        build :json_respondent_data,
+              address_attributes: build(:json_address_data, response_to_repair.respondent.address.attributes),
+              **response_to_repair.respondent.attributes.symbolize_keys
+      end
+      let(:input_representative_attributes) { response_to_repair.representative&.attributes&.to_h&.with_indifferent_access || {} }
+
+      def perform_action
+        post '/api/v2/respondents/repair_response', params: input_json.to_json, headers: default_headers
+      end
+
+      before do
+        perform_action
+      end
+    end
+
+    shared_context 'with transactions off for use with other processes' do
+      around do |example|
+        old = use_transactional_tests
+        self.use_transactional_tests = false
+        example.run
+        self.use_transactional_tests = old
+      end
+    end
+
+    shared_context 'with fake sidekiq' do
+      around do |example|
+        begin
+          original_adapter = ActiveJob::Base.queue_adapter
+          ActiveJob::Base.queue_adapter = :test
+          ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+          ActiveJob::Base.queue_adapter.performed_jobs.clear
+          example.run
+        ensure
+          ActiveJob::Base.queue_adapter = original_adapter
+        end
+      end
+
+      def run_background_jobs
+        previous_value = ActiveJob::Base.queue_adapter.perform_enqueued_jobs
+        ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
+        ActiveJob::Base.queue_adapter.enqueued_jobs.select { |j| j[:job] == EventJob }.each do |job|
+          job[:job].perform_now(*ActiveJob::Arguments.deserialize(job[:args]))
+        end
+      ensure
+        ActiveJob::Base.queue_adapter.perform_enqueued_jobs = previous_value
+      end
+    end
+
+    shared_context 'with background jobs running' do
+      before do |example|
+        next if example.metadata[:background_jobs] == :disable
+
+        run_background_jobs
+        force_export_now
+      end
+    end
+
+    shared_examples 'any response variation' do
+      it 'responds with a 201 status', background_jobs: :disable do
+        # Assert - Make sure we get a 201 - to say the commands have been accepted
+        expect(response).to have_http_status(:accepted)
+      end
+
+      it 'returns status of accepted', background_jobs: :disable do
+        expect(json_response).to include status: 'accepted'
+      end
+
+      it 'returns identical data if called twice with the same uuid', background_jobs: :disable do
+        # Arrange - get the response from the first call and reset the session ready for the second
+        response1 = JSON.parse(response.body).with_indifferent_access
+        reset!
+
+        # Act - Call the endpoint for the second time
+        perform_action
+        response2 = JSON.parse(response.body).with_indifferent_access
+
+        # Arrange - check they are identical
+        expect(response1).to eq response2
+      end
+
+      it 'creates no more records if called a second time with same uuid', background_jobs: :disable do
+
+        # Assert
+        expect { perform_action }.not_to change(Response, :count)
+      end
+    end
+
+    shared_examples 'a response exported to primary ATOS' do |exclude_contents: false|
+      it 'creates a valid txt file in the correct place in the landing folder' do
+        # Assert - Make sure we have a file with the correct contents and correct filename pattern somewhere in the zip files produced
+        reference = response_to_repair.reference
+        respondent_name = response_to_repair.respondent.name
+        output_filename_txt = "#{reference}_ET3_#{formatted_name_for_filename(respondent_name)}.txt"
+        expect(staging_folder.et3_txt_file(output_filename_txt)).to have_correct_file_structure(errors: errors)
+      end
+
+      it 'creates a valid txt file with correct header data' do
+        next if exclude_contents
+
+        # Assert - Make sure we have a file with the correct contents and correct filename pattern somewhere in the zip files produced
+        reference = response_to_repair.reference
+        respondent_name = response_to_repair.respondent.name
+        output_filename_txt = "#{reference}_ET3_#{formatted_name_for_filename(respondent_name)}.txt"
+        expect(staging_folder.et3_txt_file(output_filename_txt)).to have_correct_contents_for(
+          response: input_response_attributes,
+          respondent: input_respondent_attributes,
+          representative: input_representative_attributes,
+          errors: errors
+        ), -> { errors.join("\n") }
+      end
+
+      it 'creates a valid pdf file the data filled in correctly' do
+        next if exclude_contents
+
+        # Assert - Make sure we have a file with the correct contents and correct filename pattern somewhere in the zip files produced
+        reference = response_to_repair.reference
+        respondent_name = response_to_repair.respondent.name
+        output_filename_pdf = "#{reference}_ET3_#{formatted_name_for_filename(respondent_name)}.pdf"
+        expect(staging_folder.et3_pdf_file(output_filename_pdf, template: response_to_repair.pdf_template_reference)).to have_correct_contents_for(
+          response: input_response_attributes,
+          respondent: input_respondent_attributes,
+          representative: input_representative_attributes,
+          errors: errors
+        ), -> { errors.join("\n") }
+      end
+    end
+
+    shared_examples 'a response exported to secondary ATOS' do
+      it 'creates a valid txt file in the correct place in the landing folder' do
+        # Assert - Make sure we have a file with the correct contents and correct filename pattern somewhere in the zip files produced
+        reference = response_to_repair.reference
+        respondent_name = response_to_repair.respondent.name
+        output_filename_txt = "#{reference}_ET3_#{formatted_name_for_filename(respondent_name)}.txt"
+        expect(secondary_staging_folder.et3_txt_file(output_filename_txt)).to have_correct_file_structure(errors: errors)
+      end
+
+      it 'creates a valid txt file with correct header data' do
+        # Assert - Make sure we have a file with the correct contents and correct filename pattern somewhere in the zip files produced
+        reference = response_to_repair.reference
+        respondent_name = response_to_repair.respondent.name
+        output_filename_txt = "#{reference}_ET3_#{formatted_name_for_filename(respondent_name)}.txt"
+        expect(secondary_staging_folder.et3_txt_file(output_filename_txt)).to have_correct_contents_for(
+          response: input_response_attributes,
+          respondent: input_respondent_attributes,
+          representative: input_representative_attributes,
+          errors: errors
+        ), -> { errors.join("\n") }
+      end
+
+      it 'creates a valid pdf file the data filled in correctly' do
+        # Assert - Make sure we have a file with the correct contents and correct filename pattern somewhere in the zip files produced
+        reference = response_to_repair.reference
+        respondent_name = response_to_repair.respondent.name
+        output_filename_pdf = "#{reference}_ET3_#{formatted_name_for_filename(respondent_name)}.pdf"
+        expect(secondary_staging_folder.et3_pdf_file(output_filename_pdf, template: response_to_repair.pdf_template_reference)).to have_correct_contents_for(
+          response: input_response_attributes,
+          respondent: input_respondent_attributes,
+          representative: input_representative_attributes,
+          errors: errors
+        ), -> { errors.join("\n") }
+      end
+    end
+
+    shared_examples 'any bad request error variation' do
+      it 'responds with a 400 status', background_jobs: :disable do
+        # Assert - Make sure we get a 400 - to say the commands have not been accepted
+        expect(response).to have_http_status(:bad_request)
+      end
+
+      it 'returns the status  as not accepted', background_jobs: :disable do
+        # Assert - Make sure we get the uuid in the response
+        expect(json_response).to include status: 'not_accepted', uuid: input_factory.uuid
+      end
+    end
+
+    include_context 'with staging folder visibility'
+
+    context 'with json for a response with just a respondent' do
+      include_context 'with transactions off for use with other processes'
+      include_context 'with fake sidekiq'
+      include_context 'with setup for any response'
+      include_context 'with background jobs running'
+      include_examples 'any response variation'
+      include_examples 'a response exported to primary ATOS'
+      let(:response_to_repair) { create(:response, :broken_with_files_missing, :with_command) }
+    end
+
+    context 'with json for a response with an rtf upload that has not yet been processed' do
+      let!(:additional_information_key) { build(:json_response_data, :with_rtf).additional_information_key }
+      rtf_file_path = Rails.root.join('spec', 'fixtures', 'example.rtf').to_s
+      include_context 'with cloud provider switching', cloud_provider: :azure_test
+      include_context 'with transactions off for use with other processes'
+      include_context 'with fake sidekiq'
+      include_context 'with setup for any response'
+      include_context 'with background jobs running'
+      include_examples 'any response variation'
+
+      let(:response_to_repair) { create(:response, :with_command, additional_information_key: additional_information_key) }
+      it 'includes the rtf file in the staging folder' do
+        reference = response_to_repair.reference
+        respondent_name = response_to_repair.respondent.name.gsub(/ /, '_')
+        output_filename_rtf = "#{reference}_ET3_Attachment_#{respondent_name}.rtf"
+        Dir.mktmpdir do |dir|
+          full_path = File.join(dir, output_filename_rtf)
+          staging_folder.extract(output_filename_rtf, to: full_path)
+          expect(full_path).to be_a_file_copy_of(rtf_file_path)
+        end
+      end
+    end
+
+    context 'with json for a response with an rtf upload that has been processed but file has been lost' do
+      let!(:additional_information_key) { build(:json_response_data, :with_rtf).additional_information_key }
+      rtf_file_path = Rails.root.join('spec', 'fixtures', 'example.rtf').to_s
+      include_context 'with cloud provider switching', cloud_provider: :azure_test
+      include_context 'with transactions off for use with other processes'
+      include_context 'with fake sidekiq'
+      include_context 'with setup for any response'
+      include_context 'with background jobs running'
+      include_examples 'any response variation'
+
+      let(:uploaded_file) do
+        create(:uploaded_file, :direct_upload, :example_response_input_rtf).tap do |uploaded_file|
+          uploaded_file.file.blob.delete
+        end
+      end
+      let(:response_to_repair) { create(:response, :with_command, additional_information_key: additional_information_key, uploaded_files: [uploaded_file]) }
+      it 'includes the rtf file in the staging folder' do
+        reference = response_to_repair.reference
+        respondent_name = response_to_repair.respondent.name.gsub(/ /, '_')
+        output_filename_rtf = "#{reference}_ET3_Attachment_#{respondent_name}.rtf"
+        Dir.mktmpdir do |dir|
+          full_path = File.join(dir, output_filename_rtf)
+          staging_folder.extract(output_filename_rtf, to: full_path)
+          expect(full_path).to be_a_file_copy_of(rtf_file_path)
+        end
+      end
+    end
+
+    context 'with json for a response with an rtf upload that has been processed successfully' do
+      let!(:additional_information_key) { build(:json_response_data, :with_rtf).additional_information_key }
+      rtf_file_path = Rails.root.join('spec', 'fixtures', 'simple_user_with_rtf.rtf').to_s
+      include_context 'with cloud provider switching', cloud_provider: :azure_test
+      include_context 'with transactions off for use with other processes'
+      include_context 'with fake sidekiq'
+      include_context 'with setup for any response'
+      include_context 'with background jobs running'
+      include_examples 'any response variation'
+
+      let(:uploaded_files) do
+        [
+          build(:uploaded_file, :upload_to_blob, :example_response_input_rtf),
+          build(:uploaded_file, :upload_to_blob, :example_response_rtf),
+          build(:uploaded_file, :upload_to_blob, :example_response_text),
+          build(:uploaded_file, :upload_to_blob, :example_response_pdf)
+        ]
+      end
+      let(:respondent_name) { 'Fred Bloggs' }
+      let(:response_to_repair) do
+        create :response,
+               :with_command,
+               additional_information_key: additional_information_key,
+               uploaded_files: uploaded_files,
+               respondent: build(:respondent, :example_data, name: respondent_name)
+      end
+      it 'includes the rtf file in the staging folder' do
+        reference = response_to_repair.reference
+        output_filename_rtf = "#{reference}_ET3_Attachment_#{respondent_name.gsub(/ /, '_')}.rtf"
+        Dir.mktmpdir do |dir|
+          full_path = File.join(dir, output_filename_rtf)
+          staging_folder.extract(output_filename_rtf, to: full_path)
+          expect(full_path).to be_a_file_copy_of(rtf_file_path)
+        end
+      end
+    end
+    context 'with json for a response with a pdf file that had been processed but lost' do
+      include_context 'with cloud provider switching', cloud_provider: :azure_test
+      include_context 'with transactions off for use with other processes'
+      include_context 'with fake sidekiq'
+      include_context 'with setup for any response'
+      include_context 'with background jobs running'
+      include_examples 'any response variation'
+      include_examples 'a response exported to primary ATOS', exclude_contents: true
+
+      let(:uploaded_files) do
+        [
+          create(:uploaded_file, :upload_to_blob, :example_response_text),
+          create(:uploaded_file, :upload_to_blob, :example_response_pdf).tap do |uploaded_file|
+            uploaded_file.file.blob.delete
+          end
+        ]
+      end
+      let(:respondent_name) { 'Fred Bloggs' }
+      let(:response_to_repair) do
+        create :response,
+               :with_command,
+               additional_information_key: nil,
+               uploaded_files: uploaded_files,
+               respondent: build(:respondent, :example_data, name: respondent_name)
+      end
+    end
+
+    context 'with json for a response that had been processed but its output txt file lost' do
+      include_context 'with cloud provider switching', cloud_provider: :azure_test
+      include_context 'with transactions off for use with other processes'
+      include_context 'with fake sidekiq'
+      include_context 'with setup for any response'
+      include_context 'with background jobs running'
+      include_examples 'any response variation'
+      include_examples 'a response exported to primary ATOS', exclude_contents: true
+
+      let(:uploaded_files) do
+        [
+          create(:uploaded_file, :upload_to_blob, :example_response_text).tap do |uploaded_file|
+            uploaded_file.file.blob.delete
+          end,
+          create(:uploaded_file, :upload_to_blob, :example_response_pdf)
+        ]
+      end
+      let(:respondent_name) { 'Fred Bloggs' }
+      let(:response_to_repair) do
+        create :response,
+               :with_command,
+               additional_information_key: nil,
+               uploaded_files: uploaded_files,
+               respondent: build(:respondent, :example_data, name: respondent_name)
+      end
+    end
+    context 'with json for a response that had been processed but its output rtf file lost' do
+      let!(:additional_information_key) { build(:json_response_data, :with_rtf).additional_information_key }
+      rtf_file_path = Rails.root.join('spec', 'fixtures', 'example.rtf').to_s
+      include_context 'with cloud provider switching', cloud_provider: :azure_test
+      include_context 'with transactions off for use with other processes'
+      include_context 'with fake sidekiq'
+      include_context 'with setup for any response'
+      include_context 'with background jobs running'
+      include_examples 'any response variation'
+
+      let(:uploaded_files) do
+        [
+          build(:uploaded_file, :upload_to_blob, :example_response_input_rtf),
+          build(:uploaded_file, :upload_to_blob, :example_response_rtf).tap do |uploaded_file|
+            uploaded_file.file.blob.delete
+          end,
+          build(:uploaded_file, :upload_to_blob, :example_response_text),
+          build(:uploaded_file, :upload_to_blob, :example_response_pdf)
+        ]
+      end
+      let(:respondent_name) { 'Fred Bloggs' }
+      let(:response_to_repair) do
+        create :response,
+               :with_command,
+               additional_information_key: additional_information_key,
+               uploaded_files: uploaded_files,
+               respondent: build(:respondent, :example_data, name: respondent_name)
+      end
+      it 'includes the rtf file in the staging folder' do
+        reference = response_to_repair.reference
+        output_filename_rtf = "#{reference}_ET3_Attachment_#{respondent_name.gsub(/ /, '_')}.rtf"
+        Dir.mktmpdir do |dir|
+          full_path = File.join(dir, output_filename_rtf)
+          staging_folder.extract(output_filename_rtf, to: full_path)
+          expect(full_path).to be_a_file_copy_of(rtf_file_path)
+        end
+      end
+
+    end
+  end
+end

--- a/vendor/gems/et_atos_export/app/services/et_atos_export/response_file_builder/build_response_rtf_file.rb
+++ b/vendor/gems/et_atos_export/app/services/et_atos_export/response_file_builder/build_response_rtf_file.rb
@@ -4,7 +4,7 @@ module EtAtosExport
       def self.call(response)
         filename = 'et3_atos_export.rtf'
         original = input_file(response: response)
-        return if original.nil?
+        return if original.nil? || output_file_present?(response: response, filename: filename)
         response.uploaded_files.build filename: filename,
           file: original.file.blob,
           checksum: original.checksum
@@ -14,7 +14,12 @@ module EtAtosExport
         response.uploaded_files.detect { |u| u.filename == 'additional_information.rtf' }
       end
 
+      def self.output_file_present?(response:, filename:)
+        response.uploaded_files.any? { |u| u.filename == filename }
+      end
+
       private_class_method :input_file
+      private_class_method :output_file_present?
     end
   end
 end

--- a/vendor/gems/et_atos_export/app/services/et_atos_export/response_file_builder/build_response_text_file.rb
+++ b/vendor/gems/et_atos_export/app/services/et_atos_export/response_file_builder/build_response_text_file.rb
@@ -4,6 +4,7 @@ module EtAtosExport
       include RenderToFile
       def self.call(response)
         filename = 'et3_atos_export.txt'
+        return if output_file_present?(response: response, filename: filename)
         response.uploaded_files.build filename: filename,
                                       file: raw_text_file(filename, response: response)
       end
@@ -27,7 +28,12 @@ module EtAtosExport
         office_service.lookup_by_case_number(response.case_number)
       end
 
+      def self.output_file_present?(response:, filename:)
+        response.uploaded_files.any? { |u| u.filename == filename }
+      end
+
       private_class_method :raw_text_file, :render, :office_for
+      private_class_method :output_file_present?
     end
   end
 end


### PR DESCRIPTION


### JIRA link (if applicable) ###




### Change description ###

This PR adds a command to the API to attempt the repair of damaged ET3 responses - i.e. where the files have been lost or never imported etc..

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
