### PR TITLE
RST-2905 Removed migrations for  commands with no root object

### DIFF
--- a/app/jobs/assign_root_object_to_commands_job.rb
+++ b/app/jobs/assign_root_object_to_commands_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# A sidekiq job to assign root object to commands (as there was a period of about
+#  6 months when they were not assigned)
+class EventJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    Command.transaction do
+      Command.where(root_object_id: nil).or(Command.where(root_object_type: nil)).find_each do |command|
+        begin
+          request_json = JSON.parse(command.request_body)
+          response_json = JSON.parse(command.response_body)
+
+          if request_json['command'] == 'SerialSequence' && request_json['data'].detect {|c| c['command'] == 'BuildResponse'}
+            next unless response_json['status'] == 'accepted'
+
+            response = Response.find_by(reference: response_json.dig('meta', 'BuildResponse', 'reference'))
+            next if response.nil?
+
+            command.update root_object_id: response.id, root_object_type: 'Response'
+          elsif request_json['command'] == 'SerialSequence' && request_json['data'].detect {|c| c['command'] == 'BuildClaim'}
+            next unless response_json['status'] == 'accepted'
+
+            claim = Claim.find_by(reference: response_json.dig('meta', 'BuildClaim', 'reference'))
+            next if claim.nil?
+
+            command.update root_object_id: claim.id, root_object_type: 'Claim'
+          end
+
+        rescue ::JSON::ParserError
+          next
+        end
+
+      end
+    end
+
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -7,3 +7,13 @@ export_claims_job:
       job_class: EtAtosExport::ClaimsExportJob
       arguments:
         -
+assign_root_object_to_commands:
+  cron: "0 0 12 * *"
+  class: "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
+  description: "AssignRootObjectToCommandsJob"
+  args:
+    -
+      job_class: AssignRootObjectToCommandsJob
+      arguments:
+        -
+

--- a/db/migrate/20201030081306_migrate_commands_with_no_root_object.rb
+++ b/db/migrate/20201030081306_migrate_commands_with_no_root_object.rb
@@ -1,44 +1,6 @@
 class MigrateCommandsWithNoRootObject < ActiveRecord::Migration[6.0]
-  class Command < ActiveRecord::Base
-    self.table_name = :commands
-  end
-
-  class Response < ActiveRecord::Base
-    self.table_name = :responses
-  end
-
-  class Claim < ActiveRecord::Base
-    self.table_name = :claims
-  end
-
   def up
-    Command.transaction do
-      Command.where(root_object_id: nil).find_each do |command|
-        begin
-          request_json = JSON.parse(command.request_body)
-          response_json = JSON.parse(command.response_body)
-
-          if request_json['command'] == 'SerialSequence' && request_json['data'].detect {|c| c['command'] == 'BuildResponse'}
-            next unless response_json['status'] == 'accepted'
-
-            response = Response.find_by(reference: response_json.dig('meta', 'BuildResponse', 'reference'))
-            next if response.nil?
-
-            command.update root_object_id: response.id, root_object_type: 'Response'
-          elsif request_json['command'] == 'SerialSequence' && request_json['data'].detect {|c| c['command'] == 'BuildClaim'}
-            next unless response_json['status'] == 'accepted'
-
-            claim = Claim.find_by(reference: response_json.dig('meta', 'BuildClaim', 'reference'))
-            next if claim.nil?
-
-            command.update root_object_id: claim.id, root_object_type: 'Claim'
-          end
-
-        rescue ::JSON::ParserError
-          next
-        end
-      end
-    end
+    # Do nothing - this migration was breaking deployment for some reason so moved it to a sidekiq job
   end
 
   def down

--- a/db/migrate/20201113104003_migrate_commands_with_no_root_object_again.rb
+++ b/db/migrate/20201113104003_migrate_commands_with_no_root_object_again.rb
@@ -1,45 +1,6 @@
 class MigrateCommandsWithNoRootObjectAgain < ActiveRecord::Migration[6.0]
-  class Command < ActiveRecord::Base
-    self.table_name = :commands
-  end
-
-  class Response < ActiveRecord::Base
-    self.table_name = :responses
-  end
-
-  class Claim < ActiveRecord::Base
-    self.table_name = :claims
-  end
-
   def up
-    Command.transaction do
-      Command.where(root_object_id: nil).or(Command.where(root_object_type: nil)).find_each do |command|
-        begin
-          request_json = JSON.parse(command.request_body)
-          response_json = JSON.parse(command.response_body)
-
-          if request_json['command'] == 'SerialSequence' && request_json['data'].detect {|c| c['command'] == 'BuildResponse'}
-            next unless response_json['status'] == 'accepted'
-
-            response = Response.find_by(reference: response_json.dig('meta', 'BuildResponse', 'reference'))
-            next if response.nil?
-
-            command.update root_object_id: response.id, root_object_type: 'Response'
-          elsif request_json['command'] == 'SerialSequence' && request_json['data'].detect {|c| c['command'] == 'BuildClaim'}
-            next unless response_json['status'] == 'accepted'
-
-            claim = Claim.find_by(reference: response_json.dig('meta', 'BuildClaim', 'reference'))
-            next if claim.nil?
-
-            command.update root_object_id: claim.id, root_object_type: 'Claim'
-          end
-
-        rescue ::JSON::ParserError
-          next
-        end
-
-      end
-    end
+    # Do nothing - this migration was breaking deployment for some reason so moved it to a sidekiq job
   end
 
   def down


### PR DESCRIPTION



### JIRA link (if applicable) ###



### Change description ###
RST-2905 Removed migrations for  commands with no root object - now done in a background job


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
