### PR TITLE
RST-3311 (ECM) CSV importer now removes spaces from all values

### DIFF
--- a/app/services/claim_claimants_file_importer_service.rb
+++ b/app/services/claim_claimants_file_importer_service.rb
@@ -67,18 +67,18 @@ class ClaimClaimantsFileImporterService
   end
 
   def build_claimant_from(row)
-    Claimant.new title: row["Title"], first_name: row['First name'].try(:downcase),
-                 last_name: row['Last name'].try(:downcase), date_of_birth: row['Date of birth'],
+    Claimant.new title: row["Title"]&.strip, first_name: row['First name']&.downcase&.strip,
+                 last_name: row['Last name']&.downcase&.strip, date_of_birth: row['Date of birth']&.strip,
                  address_attributes: address_from_row(row)
   end
 
   def address_from_row(row)
     {
-      building: row['Building number or name'].try(:downcase),
-      street: row['Street'].try(:downcase),
-      locality: row['Town/city'].try(:downcase),
-      county: row['County'].try(:downcase),
-      post_code: row['Postcode'].try(:downcase)
+      building: row['Building number or name']&.downcase&.strip,
+      street: row['Street']&.downcase&.strip,
+      locality: row['Town/city']&.downcase&.strip,
+      county: row['County']&.downcase&.strip,
+      post_code: row['Postcode']&.downcase&.strip
     }
   end
 

--- a/spec/factories/uploaded_file_factory.rb
+++ b/spec/factories/uploaded_file_factory.rb
@@ -35,6 +35,12 @@ FactoryBot.define do
       file_to_attach { { content_type: 'text/csv', filename: Rails.root.join('spec', 'fixtures', 'simple_user_with_csv_group_claims.csv') } }
     end
 
+    trait :example_claim_claimants_csv_with_spaces do
+      filename { 'et1a_first_last.csv' }
+      checksum { 'ee2714b8b731a8c1e95dffaa33f89728' }
+      file_to_attach { { content_type: 'text/csv', filename: Rails.root.join('spec', 'fixtures', 'simple_user_with_csv_group_claims_with_spaces.csv') } }
+    end
+
     trait :empty_csv do
       filename { 'et1a_first_last.csv' }
       checksum { 'ee2714b8b731a8c1e95dffaa33f89728' }

--- a/spec/fixtures/simple_user_with_csv_group_claims_with_spaces.csv
+++ b/spec/fixtures/simple_user_with_csv_group_claims_with_spaces.csv
@@ -1,0 +1,11 @@
+Title,First name,Last name,Date of birth,Building number or name,Street,Town/city,County,Postcode
+ Mrs , Tamara , Swift , 06/07/1957 , 71088 , Nova Loaf , Keelingborough , Hawaii , YY9A 2LA
+ Mr , Diana , Flatley , 24/09/1986 , 66262 , Feeney Station , West Jewelstad , Montana , R8P 0JB
+ Ms , Mariana , McCullough , 10/08/1992 , 819 , Mitchell Glen , East Oliverton , South Carolina , UH2 4NA
+ Mr , Eden , Upton , 09/01/1965 , 272 , Hoeger Lodge , West Roxane , New Mexico , PD3P 8NS
+ Miss , Annie , Schulist , 19/07/1988 , 3216 , Franecki Turnpike , Amaliahaven , Washington , F3 6NL
+ Mrs , Thad , Johns , 14/06/1993 , 66462 , Austyn Trafficway , Lake Valentin , New Jersey , RT49 2QA
+ Miss , Coleman , Kreiger , 12/05/1960 , 934 , Whitney Burgs , Emmanuelhaven , Alaska , TD6B 6JJ
+ Ms , Jensen , Deckow , 27/04/1970 , 1230 , Guiseppe Courts , South Candacebury , Arkansas , U0P 6AL
+ Mr , Darien , Bahringer , 29/06/1958 , 3497 , Wilkinson Junctions , Kihnview , Hawaii , Z2E 3WL
+ Mrs , Eulalia , Hammes , 04/10/1998 , 376 , Krajcik Wall , South Ottis , Idaho , KG2 5AJ

--- a/spec/services/claim_claimants_file_importer_service_spec.rb
+++ b/spec/services/claim_claimants_file_importer_service_spec.rb
@@ -39,6 +39,24 @@ RSpec.describe ClaimClaimantsFileImporterService do
       end
     end
 
+    context "with simple csv with leading and trailing spaces" do
+      let(:example_file_trait) { :example_claim_claimants_csv_with_spaces }
+
+      context 'with saved claim' do
+        it 'imports the rows from the csv file into the claims claimants' do
+          # Act
+          service.call
+
+          # Assert
+          map = lambda do |c|
+            c[:address] = an_object_having_attributes(c[:address])
+            an_object_having_attributes(c)
+          end
+          expect(claim.secondary_claimants.includes(:address)).to match_array normalize_claimants_from_file.map(&map)
+        end
+      end
+    end
+
     context "with csv full of horrible encoding issues" do
       let(:example_file_trait) { :example_claim_claimants_csv_bad_encoding }
 

--- a/spec/support/helpers/normalize_csv_data_helper.rb
+++ b/spec/support/helpers/normalize_csv_data_helper.rb
@@ -17,16 +17,16 @@ module EtApi
         claimants_array = []
         CSV.foreach tempfile, headers: true do |row|
           claimants_array << {
-            title: row['Title'],
-            first_name: row['First name'].try(:downcase),
-            last_name: row['Last name'].try(:downcase),
-            date_of_birth: Date.parse(row['Date of birth']),
+            title: row['Title']&.strip,
+            first_name: row['First name'].try(:downcase)&.strip,
+            last_name: row['Last name'].try(:downcase)&.strip,
+            date_of_birth: Date.parse(row['Date of birth']&.strip),
             address: {
-              building: row['Building number or name'].try(:downcase),
-              street: row['Street'].try(:downcase),
-              locality: row['Town/city'].try(:downcase),
-              county: row['County'].try(:downcase),
-              post_code: row['Postcode'].try(:downcase)
+              building: row['Building number or name'].try(:downcase)&.strip,
+              street: row['Street'].try(:downcase)&.strip,
+              locality: row['Town/city'].try(:downcase)&.strip,
+              county: row['County'].try(:downcase)&.strip,
+              post_code: row['Postcode'].try(:downcase)&.strip
             }
           }
         end


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-3311

### Change description ###

RST-3311 (ECM) CSV importer now removes spaces from all values before entry into the system


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
