### PR TITLE
RST-3855 (CCD) Files are now stored as 'system' and 'user' where only…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,4 +89,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'et_acas_api', path: 'vendor/gems/et_acas_api'
 
-gem 'et_exporter', git: 'https://github.com/hmcts/et_exporter_gem.git', tag: 'v0.4.11'
+gem 'et_exporter', git: 'https://github.com/hmcts/et_exporter_gem.git', tag: 'v1.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,10 +8,10 @@ GIT
 
 GIT
   remote: https://github.com/hmcts/et_exporter_gem.git
-  revision: 33eed7c3ff45962a1b624a0c4fac5b8654afb720
-  tag: v0.4.11
+  revision: eb238aff5583d133fd2bdabe35d90d3559bedec8
+  tag: v1.0.0
   specs:
-    et_exporter (0.4.11)
+    et_exporter (1.0.0)
       jbuilder (~> 2.9, >= 2.9.1)
       pg
       rails (>= 5.2.3)

--- a/app/commands/build_claim_details_file_command.rb
+++ b/app/commands/build_claim_details_file_command.rb
@@ -5,13 +5,15 @@ class BuildClaimDetailsFileCommand < BaseCommand
   attribute :data_url, :string
 
   def apply(root_object, **_args)
-    root_object.uploaded_files.build merged_input_data
+    root_object.uploaded_files.user_file_scope.build merged_input_data
   end
 
   private
 
   def merged_input_data
     input_data = attributes.to_h.symbolize_keys
-    input_data.merge import_file_url: input_data.delete(:data_url), import_from_key: input_data.delete(:data_from_key)
+    input_data.merge import_file_url: input_data.delete(:data_url),
+                     import_from_key: input_data.delete(:data_from_key),
+                     file_scope: 'user'
   end
 end

--- a/app/commands/build_claimants_file_command.rb
+++ b/app/commands/build_claimants_file_command.rb
@@ -5,13 +5,15 @@ class BuildClaimantsFileCommand < BaseCommand
   attribute :data_url, :string
 
   def apply(root_object, **_args)
-    root_object.uploaded_files.build merged_input_data
+    root_object.uploaded_files.user_file_scope.build merged_input_data
   end
 
   private
 
   def merged_input_data
     input_data = attributes.to_h.symbolize_keys
-    input_data.merge import_file_url: input_data.delete(:data_url), import_from_key: input_data.delete(:data_from_key)
+    input_data.merge import_file_url: input_data.delete(:data_url),
+                     import_from_key: input_data.delete(:data_from_key),
+                     file_scope: 'user'
   end
 end

--- a/app/commands/build_response_additional_information_file_command.rb
+++ b/app/commands/build_response_additional_information_file_command.rb
@@ -5,7 +5,7 @@ class BuildResponseAdditionalInformationFileCommand < BaseCommand
   attribute :data_url, :string
 
   def apply(root_object, **_args)
-    root_object.uploaded_files.build merged_input_data
+    root_object.uploaded_files.user_file_scope.build merged_input_data
   end
 
   private

--- a/app/event_handlers/prepare_claim_handler.rb
+++ b/app/event_handlers/prepare_claim_handler.rb
@@ -5,7 +5,7 @@ class PrepareClaimHandler
       ClaimImportMultipleClaimantsHandler.new.handle(claim)
       ClaimPdfFileHandler.new.handle(claim)
     end
-    rename_csv_file(claim: claim)
+    copy_csv_file(claim: claim)
     copy_rtf_file(claim: claim)
     claim.save if claim.changed?
     claim.events.claim_prepared.create
@@ -14,12 +14,12 @@ class PrepareClaimHandler
 
   private
 
-  def rename_csv_file(claim:)
+  def copy_csv_file(claim:)
     file = claim.claimants_csv_file
     return if file.nil?
     claimant = claim.primary_claimant
-    file.filename = "et1a_#{claimant[:first_name].tr(' ', '_')}_#{claimant[:last_name]}.csv"
-    file.save
+    filename = "et1a_#{claimant[:first_name].tr(' ', '_')}_#{claimant[:last_name]}.csv"
+    claim.uploaded_files.system_file_scope.create filename: filename, file: file.file.blob, checksum: file.checksum
   end
 
   def copy_rtf_file(claim:)
@@ -28,11 +28,11 @@ class PrepareClaimHandler
     filename = "et1_attachment_#{claimant[:first_name].tr(' ', '_')}_#{claimant[:last_name]}.rtf"
     return if file.nil? || output_file_present?(claim: claim, filename: filename)
 
-    claim.uploaded_files.create filename: filename, file: file.file.blob, checksum: file.checksum
+    claim.uploaded_files.system_file_scope.create filename: filename, file: file.file.blob, checksum: file.checksum
   end
 
   def output_file_present?(claim:, filename:)
-    claim.uploaded_files.any? { |u| u.filename == filename }
+    claim.uploaded_files.system_file_scope.any? { |u| u.filename == filename }
   end
 
   def with_acas_in_background(claim)
@@ -42,7 +42,7 @@ class PrepareClaimHandler
     yield
     cert = downloader.value
     if cert.is_a?(::EtAcasApi::Certificate)
-      uploaded_file = claim.uploaded_files.build(filename: "acas_#{claim.primary_respondent.name}.pdf")
+      uploaded_file = claim.uploaded_files.system_file_scope.build(filename: "acas_#{claim.primary_respondent.name}.pdf")
       uploaded_file.import_base64(cert.certificate_base64, content_type: 'application/pdf')
       claim.updated_at = Time.now.utc
       claim.events.claim_acas_requested.create data: { status: 'found' }

--- a/app/mailers/claim_mailer.rb
+++ b/app/mailers/claim_mailer.rb
@@ -14,6 +14,6 @@ class ClaimMailer < ApplicationMailer
   private
 
   def user_files
-    @claim.uploaded_files.not_hidden
+    @claim.uploaded_files.user_file_scope
   end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -24,8 +24,6 @@ class Claim < ApplicationRecord
   has_many :commands, as: :root_object
 
   before_save :cache_claimant_count
-  # @TODO RST-1080 Refactoring Tasks - 'uploaded_files' really needs renaming as these files are not only
-  #   uploaded files but can be generated internally too
 
   accepts_nested_attributes_for :secondary_claimants
   accepts_nested_attributes_for :primary_claimant
@@ -35,14 +33,14 @@ class Claim < ApplicationRecord
   #
   # @return [UploadedFile, nil] The pdf file if it exists
   def pdf_file
-    uploaded_files.detect { |f| f.filename.end_with?('.pdf') && !f.filename.start_with?('acas') }
+    uploaded_files.system_file_scope.detect { |f| f.filename.end_with?('.pdf') && !f.filename.start_with?('acas') }
   end
 
   # A claim can only have one csv file - this is it
   #
   # @return [UploadedFile, nil] The csv file if it exists
   def claimants_csv_file
-    uploaded_files.detect { |f| f.filename.downcase.ends_with?('.csv') }
+    uploaded_files.user_file_scope.detect { |f| f.filename.downcase.ends_with?('.csv') }
   end
 
   def multiple_claimants?

--- a/app/models/response.rb
+++ b/app/models/response.rb
@@ -17,7 +17,7 @@ class Response < ApplicationRecord
   end
 
   def pdf_file
-    uploaded_files.detect { |file| file.filename == 'et3_atos_export.pdf' }
+    uploaded_files.system_file_scope.detect { |file| file.filename == 'et3_atos_export.pdf' }
   end
 
   private

--- a/app/models/uploaded_file.rb
+++ b/app/models/uploaded_file.rb
@@ -8,14 +8,14 @@ class UploadedFile < ApplicationRecord
 
   has_many :response_uploaded_files, dependent: :destroy
 
-  scope :not_hidden, -> { where('filename NOT LIKE ? AND filename NOT LIKE ? AND filename NOT LIKE ? AND filename NOT ILIKE ? AND filename NOT ILIKE ?', 'acas_%', 'et1_%.txt', 'et1a_%.txt', 'et1_%.rtf', 'et1_%_trimmed.pdf') }
   scope :not_pdf, -> { where('filename NOT LIKE ?', 'et1_%.pdf') }
   scope :et1_pdf, -> { where('filename LIKE ? AND filename NOT LIKE ?', 'et1_%.pdf', 'et1_%_trimmed.pdf') }
-  scope :et1_rtf, -> { not_hidden.where('filename ILIKE ?', '%.rtf') }
-  scope :et1_csv, -> { where('filename LIKE ?', 'et1a_%.csv') }
-  scope :et3_pdf, -> { where('filename LIKE ?', 'et3_atos_export.pdf') }
-  scope :et3_input_rtf, -> { where('filename LIKE ?', 'additional_information.rtf') }
-  scope :et3_output_rtf, -> { where('filename LIKE ?', 'et3_atos_export.rtf') }
+  scope :et1_rtf, -> { user_file_scope.where('filename ILIKE ?', '%.rtf') }
+  scope :et1_csv, -> { user_file_scope.where('filename ILIKE ?', '%.csv') }
+  scope :et3_pdf, -> { system_file_scope.where('filename LIKE ?', 'et3_atos_export.pdf') }
+  scope :et3_input_rtf, -> { where('filename ILIKE ?', 'additional_information.rtf') }
+  scope :et3_output_rtf, -> { where('filename ILIKE ?', 'et3_atos_export.rtf') }
+  enum file_scope: { user: 'user', system: 'system' }, _suffix: true
 
   def to_be_imported?
     import_from_key.present? || import_file_url.present?

--- a/app/services/build_claim_pdf_file_service.rb
+++ b/app/services/build_claim_pdf_file_service.rb
@@ -15,7 +15,7 @@ class BuildClaimPdfFileService # rubocop:disable Metrics/ClassLength
     office_filename = "et1_#{scrubber claimant.first_name}_#{scrubber claimant.last_name}_trimmed.pdf"
 
     blobs_for_pdf_files(citizen_filename, office_filename).each do |blob|
-      source.uploaded_files.build filename: blob.filename, file: blob
+      source.uploaded_files.system_file_scope.build filename: blob.filename, file: blob
     end
   end
 
@@ -34,8 +34,8 @@ class BuildClaimPdfFileService # rubocop:disable Metrics/ClassLength
 
     path_specs = [{ et1.output_file.path => ['1-12'] }]
     path_specs << { et1a.output_file.path => ['13-15'] } if et1a
-    
-    
+
+
     [
       Tempfile.new.tap { |file| builder.cat(*path_specs, { et1.output_file.path => ['13-15'] }, file.path) },
       Tempfile.new.tap { |file| builder.cat(*path_specs, file.path) }

--- a/app/services/build_response_pdf_file_service.rb
+++ b/app/services/build_response_pdf_file_service.rb
@@ -11,7 +11,7 @@ class BuildResponsePdfFileService # rubocop:disable Metrics/ClassLength
 
   def call
     filename = 'et3_atos_export.pdf'
-    source.uploaded_files.build filename: filename,
+    source.uploaded_files.system_file_scope.build filename: filename,
                                 file: blob_for_pdf_file(filename)
   end
 

--- a/app/services/fetch_acas_certificates_service.rb
+++ b/app/services/fetch_acas_certificates_service.rb
@@ -43,7 +43,7 @@ class FetchAcasCertificatesService
 
       cert = certificate_for(respondent)
       if cert.is_a?(::EtAcasApi::Certificate)
-        uploaded_file = claim.uploaded_files.build(filename: "acas_#{respondent.name}.pdf")
+        uploaded_file = claim.uploaded_files.system_file_scope.build(filename: "acas_#{respondent.name}.pdf")
         uploaded_file.import_base64(cert.certificate_base64, content_type: 'application/pdf')
         claim.events.claim_acas_requested.build data: { status: 'found' }
         to_remove << respondent_id

--- a/app/views/mailers/claim_mailer/confirmation_email.et1-v1-cy.html.erb
+++ b/app/views/mailers/claim_mailer/confirmation_email.et1-v1-cy.html.erb
@@ -78,11 +78,11 @@
               <tr>
                 <td valign="top" width="185">
                   <p style="font-family:arial; font-size:16px; color:#6F777B;">Dogfennau ychwanegol:</p></td>
-                <% if @claim.uploaded_files.not_hidden.not_pdf.empty? %>
+                <% if @claim.uploaded_files.user_file_scope.not_pdf.empty? %>
                   <td valign="top"><p style="font-family:arial; font-size:16px;">Dim</p></td>
                 <% else %>
                   <td valign="top">
-                    <% @claim.uploaded_files.not_hidden.not_pdf.each do |file| %>
+                    <% @claim.uploaded_files.user_file_scope.not_pdf.each do |file| %>
                     <p style="font-family:arial; font-size:16px;"><%= file.filename %></p>
                     <% end %>
                   </td>

--- a/app/views/mailers/claim_mailer/confirmation_email.et1-v1-cy.text.erb
+++ b/app/views/mailers/claim_mailer/confirmation_email.et1-v1-cy.text.erb
@@ -17,10 +17,10 @@ MANYLION CYFLWYNO
 Hawliad wedi'i gwblhau:       Gweler y PDF sydd ynghlwm
 Hawliad wedi'i gyflwyno:      Cyflwynwyd ar <%= I18n.l @claim.date_of_receipt, format: '%d %B %Y', locale: 'cy' %>
 Swyddfa tribiwnlys:           Cymru, Tribiwnlys Cyflogaeth, 3ydd Llawr, Llys Ynadon Caerdydd a’r Fro, Plas Fitzalan, Caerdydd, CF24 0RA
-Dogfennau ychwanegol:         <%- if @claim.uploaded_files.not_hidden.not_pdf.empty? %>
+Dogfennau ychwanegol:         <%- if @claim.uploaded_files.user_file_scope.not_pdf.empty? %>
 Dim
 <%- else %>
-<%- @claim.uploaded_files.not_hidden.not_pdf.each_with_index do |file, idx| %>
+<%- @claim.uploaded_files.user_file_scope.not_pdf.each_with_index do |file, idx| %>
 <%= ' ' * 30 unless idx == 0 %><%= file.filename %>
 <% end %>
 <% end %>

--- a/app/views/mailers/claim_mailer/confirmation_email.et1-v1-en.html.erb
+++ b/app/views/mailers/claim_mailer/confirmation_email.et1-v1-en.html.erb
@@ -79,11 +79,11 @@
               <tr>
                 <td valign="top" width="185">
                   <p style="font-family:arial; font-size:16px; color:#6F777B;">Additional documents:</p></td>
-                <% if @claim.uploaded_files.not_hidden.not_pdf.empty? %>
+                <% if @claim.uploaded_files.user_file_scope.not_pdf.empty? %>
                   <td valign="top"><p style="font-family:arial; font-size:16px;">None</p></td>
                 <% else %>
                   <td valign="top">
-                    <% @claim.uploaded_files.not_hidden.not_pdf.each do |file| %>
+                    <% @claim.uploaded_files.user_file_scope.not_pdf.each do |file| %>
                     <p style="font-family:arial; font-size:16px;"><%= file.filename %></p>
                     <% end %>
                   </td>

--- a/app/views/mailers/claim_mailer/confirmation_email.et1-v1-en.text.erb
+++ b/app/views/mailers/claim_mailer/confirmation_email.et1-v1-en.text.erb
@@ -18,10 +18,10 @@ SUBMISSION DETAILS
 Claim completed:       See attached PDF
 Claim submitted:       Submitted <%= @claim.date_of_receipt.strftime('%d %B %Y') %>
 Tribunal office:       <%= @office.name %>, <%= @office.email %>, <%= @office.telephone %>
-Additional documents:  <%- if @claim.uploaded_files.not_hidden.not_pdf.empty? %>
+Additional documents:  <%- if @claim.uploaded_files.user_file_scope.not_pdf.empty? %>
 None
 <%- else %>
-<%- @claim.uploaded_files.not_hidden.not_pdf.each_with_index do |file, idx| %>
+<%- @claim.uploaded_files.user_file_scope.not_pdf.each_with_index do |file, idx| %>
 <%= ' ' * 23 unless idx == 0 %><%= file.filename %>
 <% end %>
 <% end %>

--- a/db/migrate/20211129142635_add_file_scope_to_uploaded_files.rb
+++ b/db/migrate/20211129142635_add_file_scope_to_uploaded_files.rb
@@ -1,0 +1,6 @@
+class AddFileScopeToUploadedFiles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :uploaded_files, :file_scope, :string, default: 'system'
+    add_index :uploaded_files, :file_scope, unique: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_28_074000) do
+ActiveRecord::Schema.define(version: 2021_11_29_142635) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -466,6 +466,8 @@ ActiveRecord::Schema.define(version: 2021_07_28_074000) do
     t.datetime "updated_at", null: false
     t.string "import_file_url"
     t.string "import_from_key"
+    t.string "file_scope", default: "system"
+    t.index ["file_scope"], name: "index_uploaded_files_on_file_scope"
   end
 
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"

--- a/spec/commands/build_claim_details_file_command_spec.rb
+++ b/spec/commands/build_claim_details_file_command_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BuildClaimDetailsFileCommand do
 
   let(:uuid) { SecureRandom.uuid }
   let(:data) { build(:json_file_data, :simple_user_with_rtf).as_json.stringify_keys }
-  let(:root_object) { Claim.new }
+  let(:root_object) { create(:claim) }
 
   include_context 'with disabled event handlers'
 
@@ -13,9 +13,10 @@ RSpec.describe BuildClaimDetailsFileCommand do
     it 'applies the data to the root object' do
       # Act
       command.apply(root_object)
+      root_object.save!
 
       # Assert
-      expect(root_object.uploaded_files).to include an_object_having_attributes(data.except('data_from_key', 'data_url'))
+      expect(root_object.uploaded_files.user_file_scope).to include an_object_having_attributes(data.except('data_from_key', 'data_url'))
     end
   end
 end

--- a/spec/commands/build_claimants_file_command_spec.rb
+++ b/spec/commands/build_claimants_file_command_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BuildClaimantsFileCommand do
       command.apply(root_object)
 
       # Assert
-      expect(root_object.uploaded_files).to include an_object_having_attributes(data.except('data_from_key', 'data_url'))
+      expect(root_object.uploaded_files.filter(&:user_file_scope?)).to include an_object_having_attributes(data.except('data_from_key', 'data_url'))
     end
   end
 end

--- a/spec/factories/claim_factory.rb
+++ b/spec/factories/claim_factory.rb
@@ -41,31 +41,31 @@ FactoryBot.define do
 
     trait :with_pdf_file do
       after(:build) do |claim, _evaluator|
-        claim.uploaded_files << build(:uploaded_file, :example_pdf)
+        claim.uploaded_files << build(:uploaded_file, :example_pdf, :system_file_scope)
       end
     end
 
     trait :with_text_file do
       after(:build) do |claim, _evaluator|
-        claim.uploaded_files << build(:uploaded_file, :example_claim_text)
+        claim.uploaded_files << build(:uploaded_file, :example_claim_text, :system_file_scope)
       end
     end
 
     trait :with_rtf_file do
       after(:build) do |claim, _evaluator|
-        claim.uploaded_files << build(:uploaded_file, :example_claim_rtf)
+        claim.uploaded_files << build(:uploaded_file, :example_claim_rtf, :system_file_scope)
       end
     end
 
     trait :with_claimants_text_file do
       after(:build) do |claim, _evaluator|
-        claim.uploaded_files << build(:uploaded_file, :example_claim_claimants_text)
+        claim.uploaded_files << build(:uploaded_file, :example_claim_claimants_text, :system_file_scope)
       end
     end
 
     trait :with_claimants_csv_file do
       after(:build) do |claim, _evaluator|
-        claim.uploaded_files << build(:uploaded_file, :example_claim_claimants_csv)
+        claim.uploaded_files << build(:uploaded_file, :example_claim_claimants_csv, :user_file_scope)
       end
     end
 
@@ -130,8 +130,7 @@ FactoryBot.define do
           build(:claimant, :eulalia_hammes)
         ]
       end
-      uploaded_files { [build(:uploaded_file, :example_data), build(:uploaded_file, :example_claim_claimants_csv)] }
+      uploaded_files { [build(:uploaded_file, :example_data, :system_file_scope), build(:uploaded_file, :example_claim_claimants_csv, :user_file_scope)] }
     end
-
   end
 end

--- a/spec/factories/response_factory.rb
+++ b/spec/factories/response_factory.rb
@@ -46,31 +46,31 @@ FactoryBot.define do
 
     trait :with_pdf_file do
       after(:build) do |response, _evaluator|
-        response.uploaded_files << build(:uploaded_file, :example_response_pdf)
+        response.uploaded_files << build(:uploaded_file, :example_response_pdf, :system_file_scope)
       end
     end
 
     trait :with_text_file do
       after(:build) do |response, _evaluator|
-        response.uploaded_files << build(:uploaded_file, :example_response_text)
+        response.uploaded_files << build(:uploaded_file, :example_response_text, :system_file_scope)
       end
     end
 
     trait :with_rtf_file do
       after(:build) do |response, _evaluator|
-        response.uploaded_files << build(:uploaded_file, :example_response_rtf)
+        response.uploaded_files << build(:uploaded_file, :example_response_rtf, :system_file_scope)
       end
     end
 
     trait :with_input_rtf_file do
       after(:build) do |response, _evaluator|
-        response.uploaded_files << build(:uploaded_file, :example_response_input_rtf)
+        response.uploaded_files << build(:uploaded_file, :example_response_input_rtf, :user_file_scope)
       end
     end
 
     trait :with_wrong_input_rtf_file do
       after(:build) do |response, _evaluator|
-        response.uploaded_files << build(:uploaded_file, :example_response_wrong_input_rtf)
+        response.uploaded_files << build(:uploaded_file, :example_response_wrong_input_rtf, :user_file_scope)
       end
     end
 

--- a/spec/factories/uploaded_file_factory.rb
+++ b/spec/factories/uploaded_file_factory.rb
@@ -118,6 +118,14 @@ FactoryBot.define do
       upload_method { :azure_test }
     end
 
+    trait :user_file_scope do
+      file_scope { 'user' }
+    end
+
+    trait :system_file_scope do
+      file_scope { 'system' }
+    end
+
     after(:build) do |uploaded_file, evaluator|
       next if evaluator.file_to_attach.nil?
       config = Rails.configuration.active_storage

--- a/spec/requests/v2/repair_response_spec.rb
+++ b/spec/requests/v2/repair_response_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe 'Repair Response Request', type: :request do
       include_examples 'any response variation'
 
       let(:uploaded_file) do
-        create(:uploaded_file, :direct_upload, :example_response_input_rtf).tap do |uploaded_file|
+        create(:uploaded_file, :direct_upload, :example_response_input_rtf, :user_file_scope).tap do |uploaded_file|
           uploaded_file.file.blob.delete
         end
       end
@@ -317,7 +317,7 @@ RSpec.describe 'Repair Response Request', type: :request do
       include_examples 'any response variation'
 
       let(:uploaded_file) do
-        create(:uploaded_file, :direct_upload, :example_response_input_rtf).tap do |uploaded_file|
+        create(:uploaded_file, :direct_upload, :example_response_input_rtf, :user_file_scope).tap do |uploaded_file|
           uploaded_file.file.attachment.delete
         end
       end
@@ -346,10 +346,10 @@ RSpec.describe 'Repair Response Request', type: :request do
 
       let(:uploaded_files) do
         [
-          build(:uploaded_file, :upload_to_blob, :example_response_input_rtf),
-          build(:uploaded_file, :upload_to_blob, :example_response_rtf),
-          build(:uploaded_file, :upload_to_blob, :example_response_text),
-          build(:uploaded_file, :upload_to_blob, :example_response_pdf)
+          build(:uploaded_file, :upload_to_blob, :example_response_input_rtf, :user_file_scope),
+          build(:uploaded_file, :upload_to_blob, :example_response_rtf, :system_file_scope),
+          build(:uploaded_file, :upload_to_blob, :example_response_text, :system_file_scope),
+          build(:uploaded_file, :upload_to_blob, :example_response_pdf, :system_file_scope)
         ]
       end
       let(:respondent_name) { 'Fred Bloggs' }
@@ -381,8 +381,8 @@ RSpec.describe 'Repair Response Request', type: :request do
 
       let(:uploaded_files) do
         [
-          create(:uploaded_file, :upload_to_blob, :example_response_text),
-          create(:uploaded_file, :upload_to_blob, :example_response_pdf).tap do |uploaded_file|
+          create(:uploaded_file, :upload_to_blob, :example_response_text, :system_file_scope),
+          create(:uploaded_file, :upload_to_blob, :example_response_pdf, :system_file_scope).tap do |uploaded_file|
             uploaded_file.file.blob.delete
           end
         ]
@@ -408,10 +408,10 @@ RSpec.describe 'Repair Response Request', type: :request do
 
       let(:uploaded_files) do
         [
-          create(:uploaded_file, :upload_to_blob, :example_response_text).tap do |uploaded_file|
+          create(:uploaded_file, :upload_to_blob, :example_response_text, :system_file_scope).tap do |uploaded_file|
             uploaded_file.file.blob.delete
           end,
-          create(:uploaded_file, :upload_to_blob, :example_response_pdf)
+          create(:uploaded_file, :upload_to_blob, :example_response_pdf, :system_file_scope)
         ]
       end
       let(:respondent_name) { 'Fred Bloggs' }
@@ -435,12 +435,12 @@ RSpec.describe 'Repair Response Request', type: :request do
 
       let(:uploaded_files) do
         [
-          build(:uploaded_file, :upload_to_blob, :example_response_input_rtf),
-          build(:uploaded_file, :upload_to_blob, :example_response_rtf).tap do |uploaded_file|
+          build(:uploaded_file, :upload_to_blob, :example_response_input_rtf, :user_file_scope),
+          build(:uploaded_file, :upload_to_blob, :example_response_rtf, :system_file_scope).tap do |uploaded_file|
             uploaded_file.file.blob.delete
           end,
-          build(:uploaded_file, :upload_to_blob, :example_response_text),
-          build(:uploaded_file, :upload_to_blob, :example_response_pdf)
+          build(:uploaded_file, :upload_to_blob, :example_response_text, :system_file_scope),
+          build(:uploaded_file, :upload_to_blob, :example_response_pdf, :system_file_scope)
         ]
       end
       let(:respondent_name) { 'Fred Bloggs' }

--- a/spec/services/build_claim_pdf_file_service_spec.rb
+++ b/spec/services/build_claim_pdf_file_service_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BuildClaimPdfFileService do
         claim.save!
 
         # Assert
-        uploaded_file = claim.uploaded_files.where(filename: correct_filename).first
+        uploaded_file = claim.uploaded_files.system_file_scope.where(filename: correct_filename).first
         Dir.mktmpdir do |dir|
           full_path = File.join(dir, correct_filename)
           uploaded_file.download_blob_to(full_path)
@@ -125,7 +125,7 @@ RSpec.describe BuildClaimPdfFileService do
         claim.save!
 
         # Assert
-        uploaded_file = claim.uploaded_files.where(filename: correct_filename).first
+        uploaded_file = claim.uploaded_files.system_file_scope.where(filename: correct_filename).first
         Dir.mktmpdir do |dir|
           full_path = File.join(dir, correct_filename)
           uploaded_file.download_blob_to(full_path)

--- a/spec/services/build_response_pdf_file_service_spec.rb
+++ b/spec/services/build_response_pdf_file_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe BuildResponsePdfFileService do
         response.save!
 
         # Assert
-        uploaded_file = response.uploaded_files.where(filename: 'et3_atos_export.pdf').first
+        uploaded_file = response.uploaded_files.system_file_scope.where(filename: 'et3_atos_export.pdf').first
         Dir.mktmpdir do |dir|
           full_path = File.join(dir, 'et3_atos_export.pdf')
           uploaded_file.download_blob_to(full_path)
@@ -82,7 +82,7 @@ RSpec.describe BuildResponsePdfFileService do
         response.save!
 
         # Assert
-        uploaded_file = response.uploaded_files.where(filename: 'et3_atos_export.pdf').first
+        uploaded_file = response.uploaded_files.system_file_scope.where(filename: 'et3_atos_export.pdf').first
         Dir.mktmpdir do |dir|
           full_path = File.join(dir, 'et3_atos_export.pdf')
           uploaded_file.download_blob_to(full_path)
@@ -99,7 +99,7 @@ RSpec.describe BuildResponsePdfFileService do
         response.save!
 
         # Assert
-        uploaded_file = response.uploaded_files.where(filename: 'et3_atos_export.pdf').first
+        uploaded_file = response.uploaded_files.system_file_scope.where(filename: 'et3_atos_export.pdf').first
         Dir.mktmpdir do |dir|
           full_path = File.join(dir, 'et3_atos_export.pdf')
           uploaded_file.download_blob_to(full_path)

--- a/spec/services/claim_claimants_file_importer_service_spec.rb
+++ b/spec/services/claim_claimants_file_importer_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ClaimClaimantsFileImporterService do
   let(:built_claim) do
     claimant = build(:claimant)
     build :claim,
-      uploaded_files: [build(:uploaded_file, example_file_trait, filename: "et1a_#{claimant[:first_name].tr(' ', '_')}_#{claimant[:last_name]}.csv")],
+      uploaded_files: [build(:uploaded_file, example_file_trait, :user_file_scope, filename: "et1a_#{claimant[:first_name].tr(' ', '_')}_#{claimant[:last_name]}.csv")],
       primary_claimant: claimant
   end
   let(:claim) { built_claim.tap(&:save!) }

--- a/spec/services/et_atos_export/claim_file_builder/build_claim_text_file_spec.rb
+++ b/spec/services/et_atos_export/claim_file_builder/build_claim_text_file_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe EtAtosExport::ClaimFileBuilder::BuildClaimTextFile do
         builder.call(claim)
 
         # Assert
-        expect(claim.uploaded_files).to include an_object_having_attributes filename: 'et1_First_Last.txt',
-                                                                            file: be_a_stored_file
+        expect(claim.uploaded_files.filter(&:system_file_scope?)).to include an_object_having_attributes filename: 'et1_First_Last.txt',
+                                                                             file: be_a_stored_file
 
       end
 
@@ -23,7 +23,7 @@ RSpec.describe EtAtosExport::ClaimFileBuilder::BuildClaimTextFile do
         claim.save
 
         # Assert
-        uploaded_file = claim.uploaded_files.where(filename: 'et1_First_Last.txt').first
+        uploaded_file = claim.uploaded_files.system_file_scope.where(filename: 'et1_First_Last.txt').first
         expect(uploaded_file.file.download).to be_valid_et1_claim_text(claim: claim)
       end
     end
@@ -36,8 +36,8 @@ RSpec.describe EtAtosExport::ClaimFileBuilder::BuildClaimTextFile do
         builder.call(claim)
 
         # Assert
-        expect(claim.uploaded_files).to include an_object_having_attributes filename: 'et1_First_Last.txt',
-                                                                            file: be_a_stored_file
+        expect(claim.uploaded_files.filter(&:system_file_scope?)).to include an_object_having_attributes filename: 'et1_First_Last.txt',
+                                                                             file: be_a_stored_file
 
       end
 
@@ -47,7 +47,7 @@ RSpec.describe EtAtosExport::ClaimFileBuilder::BuildClaimTextFile do
         claim.save
 
         # Assert
-        uploaded_file = claim.uploaded_files.where(filename: 'et1_First_Last.txt').first
+        uploaded_file = claim.uploaded_files.system_file_scope.where(filename: 'et1_First_Last.txt').first
         expect(uploaded_file.file.download).to be_valid_et1_claim_text(claim: claim)
       end
     end

--- a/spec/services/et_atos_export/claim_file_builder/build_claimants_text_file_spec.rb
+++ b/spec/services/et_atos_export/claim_file_builder/build_claimants_text_file_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe EtAtosExport::ClaimFileBuilder::BuildClaimantsTextFile do
         builder.call(claim)
 
         # Assert
-        expect(claim.uploaded_files).to include an_object_having_attributes filename: 'et1a_First_Last.txt',
+        expect(claim.uploaded_files.filter(&:system_file_scope?)).to include an_object_having_attributes filename: 'et1a_First_Last.txt',
                                                                             file: be_a_stored_file
       end
 
@@ -21,7 +21,7 @@ RSpec.describe EtAtosExport::ClaimFileBuilder::BuildClaimantsTextFile do
         claim.save
 
         # Assert
-        uploaded_file = claim.uploaded_files.where(filename: 'et1a_First_Last.txt').first
+        uploaded_file = claim.uploaded_files.system_file_scope.where(filename: 'et1a_First_Last.txt').first
         expect(uploaded_file.file.download).to be_valid_et1a_claim_text(claim: claim)
       end
     end

--- a/spec/services/et_atos_export/response_file_builder/build_response_rtf_file_spec.rb
+++ b/spec/services/et_atos_export/response_file_builder/build_response_rtf_file_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe EtAtosExport::ResponseFileBuilder::BuildResponseRtfFile do
   let(:errors) { [] }
 
   describe '#call' do
-    let(:response) { build(:response, :with_input_rtf_file) }
+    let(:response) { create(:response, :with_input_rtf_file) }
 
     it 'stores an ET3 response file with the correct filename' do
       # Act
       builder.call(response)
 
       # Assert
-      expect(response.uploaded_files).to include an_object_having_attributes filename: 'et3_atos_export.rtf',
+      expect(response.uploaded_files.filter(&:system_file_scope?)).to include an_object_having_attributes filename: 'et3_atos_export.rtf',
                                                                              file: be_a_stored_file
     end
 
@@ -23,10 +23,10 @@ RSpec.describe EtAtosExport::ResponseFileBuilder::BuildResponseRtfFile do
       response.save!
 
       # Assert
-      uploaded_file = response.uploaded_files.where(filename: 'et3_atos_export.rtf').first
+      uploaded_file = response.uploaded_files.system_file_scope.where(filename: 'et3_atos_export.rtf').first
       Dir.mktmpdir do |dir|
         original_path = File.join(dir, 'original.rtf')
-        original_file = response.uploaded_files.detect { |f| f.filename == 'additional_information.rtf' }
+        original_file = response.uploaded_files.user_file_scope.detect { |f| f.filename == 'additional_information.rtf' }
 
         full_path = File.join(dir, 'et3_atos_export.rtf')
         uploaded_file.download_blob_to(full_path)

--- a/spec/services/et_atos_export/response_file_builder/build_response_text_file_spec.rb
+++ b/spec/services/et_atos_export/response_file_builder/build_response_text_file_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe ::EtAtosExport::ResponseFileBuilder::BuildResponseTextFile do
         builder.call(response)
 
         # Assert
-        expect(response.uploaded_files).to include an_object_having_attributes filename: 'et3_atos_export.txt',
-                                                                               file: be_a_stored_file
+        expect(response.uploaded_files.filter(&:system_file_scope?)).to include an_object_having_attributes filename: 'et3_atos_export.txt',
+                                                                                                 file: be_a_stored_file
 
       end
 
@@ -23,7 +23,7 @@ RSpec.describe ::EtAtosExport::ResponseFileBuilder::BuildResponseTextFile do
         response.save!
 
         # Assert
-        uploaded_file = response.uploaded_files.where(filename: 'et3_atos_export.txt').first
+        uploaded_file = response.uploaded_files.system_file_scope.where(filename: 'et3_atos_export.txt').first
         Dir.mktmpdir do |dir|
           full_path = File.join(dir, 'et3_atos_export.txt')
           uploaded_file.download_blob_to(full_path)
@@ -40,7 +40,7 @@ RSpec.describe ::EtAtosExport::ResponseFileBuilder::BuildResponseTextFile do
         response.save!
 
         # Assert
-        uploaded_file = response.uploaded_files.where(filename: 'et3_atos_export.txt').first
+        uploaded_file = response.uploaded_files.system_file_scope.where(filename: 'et3_atos_export.txt').first
         Dir.mktmpdir do |dir|
           full_path = File.join(dir, 'et3_atos_export.txt')
           uploaded_file.download_blob_to(full_path)
@@ -53,13 +53,13 @@ RSpec.describe ::EtAtosExport::ResponseFileBuilder::BuildResponseTextFile do
     end
 
     context 'with a representative' do
-      let(:response) { build(:response, :example_data, :with_representative) }
+      let(:response) { create(:response, :example_data, :with_representative) }
 
       include_examples 'for any response variation'
     end
 
     context 'without a representative' do
-      let(:response) { build(:response, :example_data, :without_representative) }
+      let(:response) { create(:response, :example_data, :without_representative) }
 
       include_examples 'for any response variation'
     end

--- a/spec/services/fetch_acas_certificates_service_spec.rb
+++ b/spec/services/fetch_acas_certificates_service_spec.rb
@@ -13,7 +13,7 @@ describe FetchAcasCertificatesService do
         it 'fetches primary and first 4 secondary respondents' do
           subject
 
-          expect(claim.reload.uploaded_files.count).to be 5
+          expect(claim.reload.uploaded_files.system_file_scope.count).to be 5
         end
 
         it 'has no remaining ids if all successful' do
@@ -63,22 +63,22 @@ describe FetchAcasCertificatesService do
 
         it 'does not leave an id as remaining if the acas file is already present in the claim' do
           # Arrange - Store a file in the claim with the correct name
-          claim.uploaded_files.create(filename: "acas_#{claim.primary_respondent.name}.pdf")
+          claim.uploaded_files.system_file_scope.create(filename: "acas_#{claim.primary_respondent.name}.pdf")
 
           expect(subject.remaining).to be_empty
         end
 
         it 'does not create a duplicate file if the file is already present in the claim' do
           # Arrange - Store a file in the claim with the correct name
-          claim.uploaded_files.create(filename: "acas_#{claim.primary_respondent.name}.pdf")
+          claim.uploaded_files.system_file_scope.create(filename: "acas_#{claim.primary_respondent.name}.pdf")
 
           subject
-          expect(claim.reload.uploaded_files.count).to be 5
+          expect(claim.reload.uploaded_files.system_file_scope.count).to be 5
         end
 
         it 'provides the extra files that were added' do
           # Arrange - Store a file in the claim with the correct name
-          claim.uploaded_files.create(filename: "acas_#{claim.primary_respondent.name}.pdf")
+          claim.uploaded_files.system_file_scope.create(filename: "acas_#{claim.primary_respondent.name}.pdf")
 
           expect(subject.new_files.length).to be 4
         end
@@ -87,7 +87,7 @@ describe FetchAcasCertificatesService do
           # Arrange - Store a file in the claim with the correct name
           # Arrange - modify the third respondent to use the code to return 500 error
           #  and call the service for the first time, then modify the third respondent to use the code for success
-          claim.uploaded_files.create(filename: "acas_#{claim.primary_respondent.name}.pdf")
+          claim.uploaded_files.system_file_scope.create(filename: "acas_#{claim.primary_respondent.name}.pdf")
           respondent = claim.secondary_respondents[2]
           respondent.update! acas_certificate_number: 'NE000500/78/90'
           described_class.call(claim)

--- a/vendor/gems/et_atos_export/app/services/et_atos_export/claim_export_service.rb
+++ b/vendor/gems/et_atos_export/app/services/et_atos_export/claim_export_service.rb
@@ -23,21 +23,21 @@ module EtAtosExport
     #
     # @return [UploadedFile] The text file
     def export_txt
-      claim.uploaded_files.detect { |f| f.filename.starts_with?('et1_') && f.filename.ends_with?('.txt') }
+      claim.uploaded_files.system_file_scope.detect { |f| f.filename.starts_with?('et1_') && f.filename.ends_with?('.txt') }
     end
 
     # Exports the rtf file for use by ExportService
     #
     # @return [UploadedFile] The rtf file
     def export_rtf
-      claim.uploaded_files.detect { |f| f.filename.starts_with?('et1_attachment') && f.filename.ends_with?('.rtf') }
+      claim.uploaded_files.system_file_scope.detect { |f| f.filename.starts_with?('et1_attachment') && f.filename.ends_with?('.rtf') }
     end
 
     # Exports the claimants text file for use by ExportService (produces ET1a txt file)
     #
     # @return [UploadedFile] The text file
     def export_claimants_txt
-      claim.uploaded_files.detect { |f| f.filename.starts_with?('et1a') && f.filename.ends_with?('.txt') }
+      claim.uploaded_files.system_file_scope.detect { |f| f.filename.starts_with?('et1a') && f.filename.ends_with?('.txt') }
     end
 
     # Exports the claimants csv file for use by ExportService (produces ET1a txt file)

--- a/vendor/gems/et_atos_export/app/services/et_atos_export/claim_file_builder/build_claim_text_file.rb
+++ b/vendor/gems/et_atos_export/app/services/et_atos_export/claim_file_builder/build_claim_text_file.rb
@@ -5,8 +5,8 @@ module EtAtosExport
       include RenderToFile
       def self.call(claim)
         filename = filename_for(claim: claim, prefix: 'et1', extension: 'txt')
-        claim.uploaded_files.build filename: filename,
-                                   file: raw_text_file(filename, claim: claim)
+        claim.uploaded_files.system_file_scope.build filename: filename,
+                                                     file: raw_text_file(filename, claim: claim)
       end
 
       def self.raw_text_file(filename, claim:)

--- a/vendor/gems/et_atos_export/app/services/et_atos_export/claim_file_builder/build_claimants_text_file.rb
+++ b/vendor/gems/et_atos_export/app/services/et_atos_export/claim_file_builder/build_claimants_text_file.rb
@@ -5,8 +5,8 @@ module EtAtosExport
       include RenderToFile
       def self.call(claim)
         filename = filename_for(claim: claim, prefix: 'et1a', extension: 'txt')
-        claim.uploaded_files.build filename: filename,
-                                   file: raw_claimants_text_file(filename, claim: claim)
+        claim.uploaded_files.system_file_scope.build filename: filename,
+                                                     file: raw_claimants_text_file(filename, claim: claim)
       end
 
       def self.raw_claimants_text_file(filename, claim:)

--- a/vendor/gems/et_atos_export/app/services/et_atos_export/export_service_exporters/claim_exporter.rb
+++ b/vendor/gems/et_atos_export/app/services/et_atos_export/export_service_exporters/claim_exporter.rb
@@ -59,7 +59,7 @@ module EtAtosExport
       end
 
       def claim_has_rtf?(claim:)
-        claim.uploaded_files.any? { |f| f.filename.starts_with?('et1_attachment') && f.filename.ends_with?('.rtf') }
+        claim.uploaded_files.system_file_scope.any? { |f| f.filename.starts_with?('et1_attachment') && f.filename.ends_with?('.rtf') }
       end
 
       def replacing_special(text)

--- a/vendor/gems/et_atos_export/app/services/et_atos_export/response_export_service.rb
+++ b/vendor/gems/et_atos_export/app/services/et_atos_export/response_export_service.rb
@@ -23,14 +23,14 @@ module EtAtosExport
     #
     # @return [UploadedFile] The text file
     def export_txt
-      response.uploaded_files.detect { |f| f.filename == 'et3_atos_export.txt' }
+      response.uploaded_files.system_file_scope.detect { |f| f.filename == 'et3_atos_export.txt' }
     end
 
     # Exports the rtf file for use by ExportService
     #
     # @return [UploadedFile] The rtf file
     def export_rtf
-      response.uploaded_files.detect { |f| f.filename == 'et3_atos_export.rtf' }
+      response.uploaded_files.system_file_scope.detect { |f| f.filename == 'et3_atos_export.rtf' }
     end
 
     attr_accessor :response, :exports

--- a/vendor/gems/et_atos_export/app/services/et_atos_export/response_file_builder/build_response_rtf_file.rb
+++ b/vendor/gems/et_atos_export/app/services/et_atos_export/response_file_builder/build_response_rtf_file.rb
@@ -5,17 +5,17 @@ module EtAtosExport
         filename = 'et3_atos_export.rtf'
         original = input_file(response: response)
         return if original.nil? || output_file_present?(response: response, filename: filename)
-        response.uploaded_files.build filename: filename,
+        response.uploaded_files.system_file_scope.build filename: filename,
           file: original.file.blob,
           checksum: original.checksum
       end
 
       def self.input_file(response:)
-        response.uploaded_files.detect { |u| u.filename == 'additional_information.rtf' }
+        response.uploaded_files.user_file_scope.detect { |u| u.filename == 'additional_information.rtf' }
       end
 
       def self.output_file_present?(response:, filename:)
-        response.uploaded_files.any? { |u| u.filename == filename }
+        response.uploaded_files.system_file_scope.any? { |u| u.filename == filename }
       end
 
       private_class_method :input_file

--- a/vendor/gems/et_atos_export/app/services/et_atos_export/response_file_builder/build_response_text_file.rb
+++ b/vendor/gems/et_atos_export/app/services/et_atos_export/response_file_builder/build_response_text_file.rb
@@ -5,8 +5,8 @@ module EtAtosExport
       def self.call(response)
         filename = 'et3_atos_export.txt'
         return if output_file_present?(response: response, filename: filename)
-        response.uploaded_files.build filename: filename,
-                                      file: raw_text_file(filename, response: response)
+        response.uploaded_files.system_file_scope.build filename: filename,
+                                                        file: raw_text_file(filename, response: response)
       end
 
       def self.raw_text_file(filename, response:)
@@ -31,7 +31,7 @@ module EtAtosExport
       end
 
       def self.output_file_present?(response:, filename:)
-        response.uploaded_files.any? { |u| u.filename == filename }
+        response.uploaded_files.system_file_scope.any? { |u| u.filename == filename }
       end
 
       private_class_method :raw_text_file, :render, :office_for


### PR DESCRIPTION
Files are now stored as 'system' and 'user' where only 'system' are exported


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/3855


### Change description ###

This PR changes the uploaded files so that they are split into 'user' files and 'system' files so that it is clear which files stay private and which get exported.

This is to stop the use of crazy scopes etc.. that try and filter them out by name which was getting un manageable

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
