### PR TITLE
(RST-5002) Added application/csv mime type to registry

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,4 @@
 
 # Add new mime types for use in respond_to blocks:
 Mime::Type.register "application/rtf", :rtf, ['text/rtf'], %w(rtf)
+Mime::Type.register "application/csv", :csv, ['text/csv'], %w(csv)

--- a/spec/requests/v2/create_blob_spec.rb
+++ b/spec/requests/v2/create_blob_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Create a blob in the direct upload storage', type: :request do
   describe 'POST /api/v2/create_blob' do
     it 'stores the csv file as a blob in the direct upload storage and identifies the content type as csv' do
       post '/api/v2/create_blob', params: { file: Rack::Test::UploadedFile.new(Rails.root.join('spec/fixtures/simple_user_with_csv_group_claims.csv'), 'application/csv', false) }, headers: default_headers
-      expect(json_response).to include data: a_hash_including(key: instance_of(String), content_type: 'text/csv', filename: 'simple_user_with_csv_group_claims.csv')
+      expect(json_response).to include data: a_hash_including(key: instance_of(String), content_type: 'application/csv', filename: 'simple_user_with_csv_group_claims.csv')
     end
 
     it 'stores the rtf file as a blob in the direct upload storage and identifies the content type as rtf' do


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-5002


### Change description ###

This PR adds the mime type application/csv so that it equals 'text/csv' - this was causing csv files to fail to be identified properly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
