### PR TITLE
(RST-5254) Seed data update for RST-5218

### DIFF
--- a/db/offices.csv
+++ b/db/offices.csv
@@ -1,26 +1,20 @@
 office_code,office_name,office_address,office_telephone,office_email,is_default
-13,Midlands (West) ET,"Centre City Tower, 5-7 Hill Street, Birmingham B5 4UU",0121 600 7780,midlandswestet@justice.gov.uk,0
+13,Midlands West,"Centre City Tower, 5-7 Hill Street, Birmingham B5 4UU",0121 600 7780,midlandswestet@justice.gov.uk,0
 14,Bristol,"Bristol Civil and Family Justice Centre, 2 Redcliff Street, Bristol, BS1 6GR",01224 593 137,bristolet@justice.gov.uk,0
-15,Bury St Edmunds,"100 Southgate Street, Bury St Edmunds, Suffolk IP33 2AQ",01284 762171,buryet@hmcts.gsi.gov.uk,0
 16,Wales,"Employment Tribunal, 3rd Floor, Cardiff and Vale Magistrates Court, Fitzalan Place, Cardiff, CF24 0RZ",029 2067 8100,cardiffet@justice.gov.uk,0
-17,Exeter,"2nd Floor, Keble House, Southernhay Gardens, Exeter EX1 1NT",01392 279665,exeteret@hmcts.gsi.gov.uk,0
 18,Leeds,"4th Floor, City Exchange, 11 Albion Street, Leeds LS1 5ES",0113 245 9741,leedset@justice.gov.uk,0
-19,Leicester,"3rd Floor, Byron House, 2a Maid Marian Way, Nottingham NG1 6HS",0115 947 5701,nottinghamet@hmcts.gsi.gov.uk,0
 22,London Central,"Victory House, 30-34 Kingsway, London WC2B 6EX",020 7273 8603,londoncentralet@justice.gov.uk,0
 23,London South,"Montague Court, 101 London Road, West Croydon CR0 2RF",020 8667 9131,londonsouthet@justice.gov.uk,0
 24,Manchester,"Alexandra House, 14-22 The Parsonage, Manchester M3 2JA",0161 833 6100,manchesteret@justice.gov.uk,0
 25,Newcastle,"Kings Court, Earl Grey Way, Royal Quays, North Shields, Tyne & Wear, NE29 6AR",0191 260 6900,newcastleet@justice.gov.uk,0
-26,Midlands (East) ET,"Nottingham Justice Centre - Employment, Carrington Street, Nottingham, NG2 1EE",0115 947 5701,midlandseastet@justice.gov.uk,0
-27,Reading,"4th Floor, 30-31 Friar Street, Reading RG1 1DX",0118 959 4917,readinget@hmcts.gsi.gov.uk,0
-31,Southampton,"Southampton Magistrates' Court, 100 The Avenue, Southampton SO17 1EY",023 8038 4200,southamptonet@hmcts.gsi.gov.uk,0
-32,East London,"2nd Floor, Anchorage House, 2 Clove Crescent, London E14 2BE",020 7538 6161,eastlondon@justice.gov.uk,0
+26,Midlands East,"Nottingham Justice Centre - Employment, Carrington Street, Nottingham, NG2 1EE",0115 947 5701,midlandseastet@justice.gov.uk,0
+32,London East,"2nd Floor, Anchorage House, 2 Clove Crescent, London E14 2BE",020 7538 6161,eastlondon@justice.gov.uk,0
 33,Watford,"3rd Floor, Radius House, 51 Clarendon Rd, Watford, WD17 1HP",01923 281 750,watfordet@justice.gov.uk,0
-34,Huntingdon,"Huntingdon Law Courts, Walden Road, Huntingdon PE29 3DW",01480 415600,huntingdonet@hmcts.gsi.gov.uk,0
 41,Glasgow,"Eagle Building, 215 Bothwell Street, Glasgow, G2 7TS",0141 204 0730,glasgowet@justice.gov.uk,0
-50,London,"Employment Appeal Tribunal, Second Floor, Fleetbank House, 2-6 Salisbury Square, London, EC4Y 8JX",020 7273 1041,londoneat@hmcts.gsi.gov.uk,0
+50,London Central,"Employment Appeal Tribunal, Second Floor, Fleetbank House, 2-6 Salisbury Square, London, EC4Y 8JX",020 7273 1041,londoneat@hmcts.gsi.gov.uk,0
 51,Edinburgh,"EAT Edinburgh, 52 Melville Street, Edinburgh, EH3 7HF",0131 225 3963,edinburgheat@hmcts.gsi.gov.uk,0
 99,Default,"Alexandra House, 14-22 The Parsonage, Manchester M3 2JA",0161 833 5113,employmentJurisdictionalSupportTeamInbox@justice.gov.uk,1
-60,Leeds,"4th Floor, City Exchange, 11 Albion Street, Leeds LS1 5ES",0113 245 9741,leedset@justice.gov.uk,0
+60,England And Wales (Reform),"4th Floor, City Exchange, 11 Albion Street, Leeds LS1 5ES",0113 245 9741,leedset@justice.gov.uk,0
 61,Leeds,"4th Floor, City Exchange, 11 Albion Street, Leeds LS1 5ES",0113 245 9741,leedset@justice.gov.uk,0
 62,Leeds,"4th Floor, City Exchange, 11 Albion Street, Leeds LS1 5ES",0113 245 9741,leedset@justice.gov.uk,0
 64,Leeds,"4th Floor, City Exchange, 11 Albion Street, Leeds LS1 5ES",0113 245 9741,leedset@justice.gov.uk,0
@@ -30,7 +24,7 @@ office_code,office_name,office_address,office_telephone,office_email,is_default
 68,Leeds,"4th Floor, City Exchange, 11 Albion Street, Leeds LS1 5ES",0113 245 9741,leedset@justice.gov.uk,0
 69,Leeds,"4th Floor, City Exchange, 11 Albion Street, Leeds LS1 5ES",0113 245 9741,leedset@justice.gov.uk,0
 70,Test10,"Test 10 address",01234 566789,test10@example.com,0
-80,Glasgow,"Eagle Building, 215 Bothwell Street, Glasgow, G2 7TS",0141 204 0730,glasgowet@justice.gov.uk,0
+80,Scotland (Reform),"Eagle Building, 215 Bothwell Street, Glasgow, G2 7TS",0141 204 0730,glasgowet@justice.gov.uk,0
 81,Glasgow,"Eagle Building, 215 Bothwell Street, Glasgow, G2 7TS",0141 204 0730,glasgowet@justice.gov.uk,0
 82,Glasgow,"Eagle Building, 215 Bothwell Street, Glasgow, G2 7TS",0141 204 0730,glasgowet@justice.gov.uk,0
 83,Glasgow,"Eagle Building, 215 Bothwell Street, Glasgow, G2 7TS",0141 204 0730,glasgowet@justice.gov.uk,0

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -76,17 +76,16 @@ ExternalSystemConfiguration.create external_system_id: ccd_glasgow.id,
 ExternalSystemConfiguration.create external_system_id: ccd_glasgow.id,
   key: 'multiples_case_type_id', value: 'Glasgow_Multiples_Dev'
 
-ExternalSystem.create! name: 'CCD Test1',
-                      reference: 'ccd_test1',
+ExternalSystem.create! name: 'CCD England And Wales (Reform)',
+                      reference: 'ccd_england_and_wales_reform',
                       enabled: true,
                       export_claims: true,
-                      export_responses: false,
+                      export_responses: true,
                       export_queue: 'external_system_ccd',
                       office_codes: [60],
                       configurations_attributes: [
-                              { key: 'case_type_id', value: 'Test1' },
-                              { key: 'multiples_case_type_id',value: 'Test1_Multiples' },
-                              { key: 'extra_headers', value: { force_failures: { token_stage: [401] } }.to_json},
+                              { key: 'case_type_id', value: 'ET_EnglandWales' },
+                              { key: 'multiples_case_type_id',value: 'ET_EnglandWales_Multiples' },
                               { key: 'send_request_id', value: 'true' }
                             ]
 ExternalSystem.create! name: 'CCD Test2',
@@ -141,16 +140,15 @@ ExternalSystem.create! name: 'CCD Test5',
                               { key: 'extra_headers', value: { force_failures: { token_stage: [401, 401, 401] } }.to_json},
                               { key: 'send_request_id', value: 'true' }
                             ]
-ExternalSystem.create! name: 'CCD Test6',
-                      reference: 'ccd_test6',
+ExternalSystem.create! name: 'CCD Scotland (Reform)',
+                      reference: 'ccd_scotland_reform',
                       enabled: true,
                       export_claims: true,
-                      export_responses: false,
+                      export_responses: true,
                       export_queue: 'external_system_ccd',
-                      office_codes: [65],
+                      office_codes: [80],
                       configurations_attributes: [
-                              { key: 'case_type_id', value: 'Test6' },
-                              { key: 'multiples_case_type_id',value: 'Test5_Multiples' },
-                              { key: 'extra_headers', value: { force_failures: { token_stage: [401, 401, 401, 504, 504, 401] } }.to_json},
+                              { key: 'case_type_id', value: 'ET_Scotland' },
+                              { key: 'multiples_case_type_id',value: 'ET_Scotland_Multiples' },
                               { key: 'send_request_id', value: 'true' }
                             ]

--- a/spec/services/office_service_spec.rb
+++ b/spec/services/office_service_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe OfficeService do
       result = service.lookup_by_case_number('6012345/2016')
 
       # Assert
-      expect(result).to be_a(Office).and(have_attributes(code: 60, name: 'Leeds'))
+      expect(result).to be_a(Office).and(have_attributes(code: 60, name: 'England And Wales (Reform)'))
     end
 
     it 'finds office 61 which translates to leeds due to new rules for new reform ET1 cases' do
@@ -107,7 +107,7 @@ RSpec.describe OfficeService do
       result = service.lookup_by_case_number('8012345/2016')
 
       # Assert
-      expect(result).to be_a(Office).and(have_attributes(code: 80, name: 'Glasgow'))
+      expect(result).to be_a(Office).and(have_attributes(code: 80, name: 'Scotland (Reform)'))
     end
 
     it 'finds office 81 which translates to glasgow due to new rules for new reform ET1 cases' do


### PR DESCRIPTION


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/


### Change description ###

This PR updates the seed data which is only used in et-full-system testing - the update is to allow the 2 special offices (60 and 80) to 'export' responses.

Even though nothing will be exported, the plan is to configure the et_ccd_exporter to find the claim that the response is for from ccd, then change the office for the response (via an async sidekiq job) accordingly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
